### PR TITLE
chore: resolve low-risk React Compiler lint rules (promote to errors)

### DIFF
--- a/app/[team]/(reports)/reports/logged/data-table.tsx
+++ b/app/[team]/(reports)/reports/logged/data-table.tsx
@@ -50,6 +50,8 @@ export function DataTable<TData, TValue>({
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [columnVisibility, setColumnVisibility] = useState({});
 
+  // TanStack Table returns functions the React Compiler can't memoize; it safely skips this component.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,

--- a/app/[team]/projects/[project]/components/data-table.tsx
+++ b/app/[team]/projects/[project]/components/data-table.tsx
@@ -37,6 +37,8 @@ export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [columnVisibility, setColumnVisibility] = useState({});
 
+  // TanStack Table returns functions the React Compiler can't memoize; it safely skips this component.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,

--- a/app/[team]/projects/[project]/components/time-chart.tsx
+++ b/app/[team]/projects/[project]/components/time-chart.tsx
@@ -84,22 +84,6 @@ const TimeChart = ({ timeEntries, totalDays }: TimeChartProps) => {
     setData(finalData);
   }, [timeEntries, totalDays, end]);
 
-  // Suppress warning for defaultProps in Recharts component
-  if (process.env.NODE_ENV !== "production") {
-    const originalWarn = console.error;
-    console.error = (...args) => {
-      if (
-        args &&
-        args?.[0]?.includes(
-          "Support for defaultProps will be removed from function components in a future major release.",
-        )
-      ) {
-        return;
-      }
-      originalWarn(...args);
-    };
-  }
-
   return (
     <Card className="select-none p-0 shadow-none">
       <CardHeader className="mt-2 flex flex-row items-center justify-between px-4 py-2">

--- a/app/[team]/projects/[project]/layout.tsx
+++ b/app/[team]/projects/[project]/layout.tsx
@@ -86,6 +86,8 @@ export default async function DashboardLayout(props: DashboardLayoutProps) {
       },
       projectId: +projectId,
       date: {
+        // Server component — runs once per request; Date.now() is fine here.
+        // eslint-disable-next-line react-hooks/purity
         gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
       },
     },
@@ -102,6 +104,8 @@ export default async function DashboardLayout(props: DashboardLayoutProps) {
       },
       projectId: +projectId,
       date: {
+        // Server component — runs once per request; Date.now() is fine here.
+        // eslint-disable-next-line react-hooks/purity
         gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
       },
       billable: true,
@@ -132,6 +136,8 @@ export default async function DashboardLayout(props: DashboardLayoutProps) {
       },
       projectId: +projectId,
       date: {
+        // Server component — runs once per request; Date.now() is fine here.
+        // eslint-disable-next-line react-hooks/purity
         gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
       },
     },

--- a/components/data-table/structure.tsx
+++ b/components/data-table/structure.tsx
@@ -24,6 +24,8 @@ export function DataTableStructure<TData, TValue>({
   rowClickHandler,
   className,
 }: DataTableProps<TData, TValue>) {
+  // TanStack Table returns functions the React Compiler can't memoize; it safely skips this component.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/components/forms/leaveForm.tsx
+++ b/components/forms/leaveForm.tsx
@@ -88,6 +88,16 @@ export function LeaveForm({ team, users, leaves }: LeaveFormProps) {
   const [loading, setLoading] = useState(false);
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
 
+  const form = useForm<z.input<typeof leaveFormSchema>, any, LeaveFormValues>({
+    resolver: zodResolver(leaveFormSchema),
+    defaultValues: {
+      userId: 0,
+      planned: { eligible: "", taken: "" },
+      unplanned: { eligible: "", taken: "" },
+      compoff: { eligible: "", taken: "" },
+    },
+  });
+
   useEffect(() => {
     const fetchLeaveRecord = () => {
       if (editId) {
@@ -134,16 +144,6 @@ export function LeaveForm({ team, users, leaves }: LeaveFormProps) {
     id: user.id,
     name: user.name || user.email,
   }));
-
-  const form = useForm<z.input<typeof leaveFormSchema>, any, LeaveFormValues>({
-    resolver: zodResolver(leaveFormSchema),
-    defaultValues: {
-      userId: 0,
-      planned: { eligible: "", taken: "" },
-      unplanned: { eligible: "", taken: "" },
-      compoff: { eligible: "", taken: "" },
-    },
-  });
 
   const handleMemberSelect = (selected: string) => {
     const memberValue = users.find((user) => user.id === +selected);

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -535,6 +535,8 @@ const SidebarMenuSkeleton = React.forwardRef<
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
+    // Cosmetic skeleton width; randomness here is intentional and harmless.
+    // eslint-disable-next-line react-hooks/purity
     return `${Math.floor(Math.random() * 40) + 50}%`;
   }, []);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ const findPlugin = (name) => nextCoreWebVitals.find((c) => c.plugins?.[name])?.p
 const reactHooks = findPlugin("react-hooks");
 const importPlugin = findPlugin("import");
 
-export default [
+const config = [
   { ignores: [".next/**", "node_modules/**", "next-env.d.ts", "generated/**"] },
   ...nextCoreWebVitals,
   eslintConfigPrettier,
@@ -27,17 +27,18 @@ export default [
       "@next/next/no-html-link-for-pages": "off",
       "react/jsx-key": "off",
       "tailwindcss/no-custom-classname": "off",
-      // The React Compiler lint rules below are newly enabled by Next 16's
-      // eslint config. They flag pre-existing patterns across the app; demoted
-      // to warnings so the deps upgrade isn't blocked. Adopt as errors and fix
-      // incrementally in a dedicated follow-up.
+      // React Compiler rules (newly enabled by Next 16). These below are clean
+      // and enforced as errors. The remaining behavioral ones stay warnings and
+      // are being fixed in tested per-file batches.
+      "react-hooks/purity": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/incompatible-library": "error",
+      "import/no-anonymous-default-export": "error",
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/refs": "warn",
-      "react-hooks/purity": "warn",
-      "react-hooks/immutability": "warn",
-      "react-hooks/incompatible-library": "warn",
       "react-hooks/exhaustive-deps": "warn",
-      "import/no-anonymous-default-export": "warn",
     },
   },
 ];
+
+export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ const reactHooks = findPlugin("react-hooks");
 const importPlugin = findPlugin("import");
 
 export default [
-  { ignores: [".next/**", "node_modules/**", "next-env.d.ts"] },
+  { ignores: [".next/**", "node_modules/**", "next-env.d.ts", "generated/**"] },
   ...nextCoreWebVitals,
   eslintConfigPrettier,
   {


### PR DESCRIPTION
**Stacked on `chore/prisma-7`** (#593), which is stacked on `chore/deps-latest` (#592). Merge in order.

Takes the "safe-now + incremental" approach to the 45 React Compiler lint warnings Next 16 introduced. The build doesn't catch these (they're runtime-behavioral), so the high-volume behavioral ones are fixed in tested batches, not blind.

## Resolved + promoted to **error** (10)
**Real fixes**
- `time-chart.tsx`: removed the obsolete `console.error` monkey-patch — it suppressed a Recharts `defaultProps` warning, but recharts 3 dropped `defaultProps`, so it's dead code (and reassigning `console.error` each render is exactly what `immutability` flags).
- `leaveForm.tsx`: moved `useForm` above the effect that calls `form.setValue` (was referenced before declaration).

**Justified per-line disables** (correct-as-is; nothing to fix in our code)
- `useReactTable` ×3 → `incompatible-library`: TanStack Table returns functions the compiler can't memoize; it safely skips those components.
- `Date.now()` ×3 in the project layout → `purity`: server component, runs once per request.
- `Math.random()` in the sidebar skeleton → `purity`: cosmetic loading width.

Rules now enforced as errors: `purity`, `immutability`, `incompatible-library`, `no-anonymous-default-export`. Also stopped linting the Prisma-generated client.

## Left as warnings (35 — deferred, tested batches)
`set-state-in-effect` (23), `refs` (11), `exhaustive-deps` (4). These change *when effects run / how refs are read* — the reports infinite-loop was exactly this category — so they want per-component runtime testing rather than a blind sweep.

## Verification
`bun run build` ✅ · `bunx tsc --noEmit` 0 ✅ · `bun run lint` ✅ (0 errors, 35 warnings)

## Follow-up
Fix the 35 behavioral warnings in small, runtime-tested batches, then promote those rules too. Optionally enable `reactCompiler: true` (Next 16) once eligible components grow — it already safely skips the flagged ones.