### PR TITLE
feat: Enhance reports and members with groups, labels

### DIFF
--- a/app/[team]/(reports)/reports/logged/columns.tsx
+++ b/app/[team]/(reports)/reports/logged/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { Circle, Info, Minus, Plus } from "lucide-react";
+import { Circle, Info, List, Minus, Plus } from "lucide-react";
 
 import { getRandomColor } from "@/lib/random-colors";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,7 @@ export interface Logged {
   image?: string;
   billable?: boolean;
   task?: string | null;
+  groups?: { id: number; name: string }[];
   subRows?: {
     id: number;
     name: string;
@@ -94,6 +95,50 @@ function BudgetCell({
   );
 }
 
+function MemberGroups({ groups }: { groups: { id: number; name: string }[] }) {
+  if (groups.length === 0) {
+    return null;
+  }
+
+  const [firstGroup, ...remainingGroups] = groups;
+  const hasMoreGroups = remainingGroups.length > 0;
+
+  const groupLabel = (
+    <Badge
+      variant="outline"
+      className="inline-flex max-w-[10rem] border-sky-200 bg-sky-50 font-normal text-sky-800 dark:border-sky-800 dark:bg-sky-950 dark:text-sky-300"
+      title={groups.map((group) => group.name).join(", ")}
+    >
+      <span className="truncate">{firstGroup.name}</span>
+      {hasMoreGroups && (
+        <>
+          <span className="mx-1 shrink-0 opacity-40">|</span>
+          <span className="shrink-0">+{remainingGroups.length}</span>
+        </>
+      )}
+    </Badge>
+  );
+
+  if (!hasMoreGroups) {
+    return groupLabel;
+  }
+
+  return (
+    <CustomTooltip
+      trigger={groupLabel}
+      content={
+        <div className="flex flex-col gap-1 text-xs">
+          {groups.map((group) => (
+            <span key={group.id}>{group.name}</span>
+          ))}
+        </div>
+      }
+      contentClassName="max-w-[200px]"
+      sideOffset={4}
+    />
+  );
+}
+
 export const columns: ColumnDef<Logged>[] = [
   {
     accessorKey: "name",
@@ -106,7 +151,7 @@ export const columns: ColumnDef<Logged>[] = [
       const value = getValue() as string;
 
       return (
-        <div className="ml-8 flex items-center gap-2" style={{ marginLeft: `${depth * 32}px` }}>
+        <div className="ml-8 flex min-w-0 items-center gap-2" style={{ marginLeft: `${depth * 32}px` }}>
           {canExpand && type !== "client" && type !== "entry" && (
             <Button
               {...{
@@ -118,39 +163,49 @@ export const columns: ColumnDef<Logged>[] = [
               {isExpanded ? <Minus size={16} /> : <Plus size={16} />}
             </Button>
           )}
-          <div
-            className={`${type === "client" ? "font-medium" : ""} ${type === "entry" ? "descendent" : ""} relative flex items-center gap-2`}
-          >
-            {type === "client" && (
-              <span
-                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-white"
-                style={{ backgroundColor: getRandomColor(original.id) }}
-              >
-                {value.charAt(0)}
-              </span>
-            )}
-            {type === "member" && (
+          {type === "member" ? (
+            <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
               <UserAvatar
                 user={{ name: original.name ?? null, image: original.image ?? null }}
-                className="h-6 w-6 bg-slate-300"
+                className="h-6 w-6 shrink-0 bg-slate-300"
               />
-            )}
-            <span className={`${type === "entry" ? "w-full md:w-[200px]" : "w-full"} line-clamp-1 shrink-0`}>
-              {value}
-            </span>
-            {type === "entry" && (
-              <span className="hidden items-center gap-2 md:inline-flex">
-                {original.task && (
-                  <Badge variant="secondary" className="shrink-0 font-normal">
-                    {original.task}
-                  </Badge>
-                )}
-                <span className="line-clamp-1 opacity-50" title={original.description ?? undefined}>
-                  {original?.description ?? ""}
+              <span className="min-w-0 flex-1 truncate">{value}</span>
+              <MemberGroups groups={original.groups ?? []} />
+            </div>
+          ) : (
+            <div
+              className={`${type === "client" ? "font-medium" : ""} ${type === "entry" ? "descendent" : ""} relative flex items-center gap-2`}
+            >
+              {type === "client" && (
+                <span
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-white"
+                  style={{ backgroundColor: getRandomColor(original.id) }}
+                >
+                  {value.charAt(0)}
                 </span>
+              )}
+              <span className={`${type === "entry" ? "w-full md:w-[200px]" : "w-full"} line-clamp-1 shrink-0`}>
+                {value}
               </span>
-            )}
-          </div>
+              {type === "entry" && (
+                <span className="hidden items-center gap-2 md:inline-flex">
+                  {original.task && (
+                    <Badge
+                      variant="secondary"
+                      className="inline-flex shrink-0 items-center font-normal"
+                      title={`Task: ${original.task}`}
+                    >
+                      <List size={12} className="mr-1 shrink-0" />
+                      {original.task}
+                    </Badge>
+                  )}
+                  <span className="line-clamp-1 opacity-50" title={original.description ?? undefined}>
+                    {original?.description ?? ""}
+                  </span>
+                </span>
+              )}
+            </div>
+          )}
         </div>
       );
     },

--- a/app/[team]/(reports)/reports/logged/data-table.tsx
+++ b/app/[team]/(reports)/reports/logged/data-table.tsx
@@ -28,6 +28,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   allClients: ClientAndUserInterface[];
   allUsers: ClientAndUserInterface[];
+  allGroups: ClientAndUserInterface[];
   hasFullAccess?: boolean;
 }
 
@@ -41,6 +42,7 @@ export function DataTable<TData, TValue>({
   data,
   allClients,
   allUsers,
+  allGroups,
   hasFullAccess,
 }: DataTableProps<TData, TValue>) {
   const router = useRouter();
@@ -109,6 +111,7 @@ export function DataTable<TData, TValue>({
         table={table}
         allClients={allClients}
         allUsers={allUsers}
+        allGroups={allGroups}
         handlePrintClick={handlePrintClick}
         hasFullAccess={hasFullAccess}
       />
@@ -136,7 +139,9 @@ export function DataTable<TData, TValue>({
               return (
                 <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                    <TableCell key={cell.id} className={cell.column.id === "name" ? "max-w-0" : undefined}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
                   ))}
                 </TableRow>
               );

--- a/app/[team]/(reports)/reports/logged/multiselect-filters.tsx
+++ b/app/[team]/(reports)/reports/logged/multiselect-filters.tsx
@@ -14,10 +14,8 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { ClientAndUserInterface } from "./data-table";
 
@@ -54,7 +52,9 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
           {values.title}
           {selectedOptions.length > 0 && (
             <>
-              <Separator orientation="vertical" className="h-4" />
+              <span className="flex self-stretch items-center" aria-hidden="true">
+                <span className="bg-border h-4 w-px shrink-0" />
+              </span>
               <Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
                 {selectedOptions.length}
               </Badge>
@@ -78,11 +78,11 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
-        <Command>
+        <Command className="overflow-hidden">
           {values.searchable && <CommandInput placeholder="Search..." />}
-          <CommandEmpty>No options found.</CommandEmpty>
-          <CommandGroup>
-            <CommandList>
+          <CommandList className="max-h-[250px]">
+            <CommandEmpty>No options found.</CommandEmpty>
+            <CommandGroup>
               {values.options.map((option) => {
                 const isSelected = selectedOptions.includes(`${option.id}`);
                 return (
@@ -106,23 +106,20 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
                   </CommandItem>
                 );
               })}
-            </CommandList>
-          </CommandGroup>
+            </CommandGroup>
+          </CommandList>
           {selectedOptions.length > 0 && (
-            <>
-              <CommandSeparator />
-              <CommandGroup>
-                <CommandItem
-                  onSelect={() => {
-                    setSelectedParams(null);
-                    setOpen(false);
-                  }}
-                  className="cursor-pointer justify-center text-center"
-                >
-                  Clear filters
-                </CommandItem>
-              </CommandGroup>
-            </>
+            <div className="border-t bg-popover p-1">
+              <CommandItem
+                onSelect={() => {
+                  setSelectedParams(null);
+                  setOpen(false);
+                }}
+                className="cursor-pointer justify-center text-center"
+              >
+                Clear filters
+              </CommandItem>
+            </div>
           )}
         </Command>
       </PopoverContent>

--- a/app/[team]/(reports)/reports/logged/page.tsx
+++ b/app/[team]/(reports)/reports/logged/page.tsx
@@ -35,11 +35,13 @@ export default async function Page(props: pageProps) {
   const selectedProject = searchParams.project;
   const selectedClients = searchParams.clients;
   const selectedMembers = searchParams.members;
+  const selectedGroups = searchParams.groups;
   const { startDate, endDate } = getStartandEndDates(selectedRange);
   const {
     data: loggedData,
     allClients,
     allUsers,
+    allGroups,
   } = await getLogged(
     params.team,
     startDate,
@@ -48,6 +50,7 @@ export default async function Page(props: pageProps) {
     selectedProject,
     selectedClients,
     selectedMembers,
+    selectedGroups,
     hasFullAccess,
   );
 
@@ -103,6 +106,7 @@ export default async function Page(props: pageProps) {
                     id: user.userId,
                     name: user.userName,
                     image: user.userImage,
+                    groups: user.userGroups,
                     hours: 0,
                     billableHours: 0,
                     subRows: [],
@@ -172,6 +176,7 @@ export default async function Page(props: pageProps) {
           data={transformedData as Logged[]}
           allClients={allClients}
           allUsers={allUsers}
+          allGroups={allGroups}
           hasFullAccess={hasFullAccess}
         />
       </div>

--- a/app/[team]/(reports)/reports/logged/toolbar.tsx
+++ b/app/[team]/(reports)/reports/logged/toolbar.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { format, startOfDay, startOfMonth, startOfToday } from "date-fns";
-import { Briefcase, CircleDollarSign, Download, FolderCog, ListRestart, Loader2, Printer, Users } from "lucide-react";
+import { Briefcase, CircleDollarSign, Download, FolderCog, ListRestart, Loader2, Printer, Tags, Users } from "lucide-react";
 import { useQueryState } from "nuqs";
 import csvDownload from "json-to-csv-export";
 
@@ -21,6 +21,7 @@ import { DateRangePicker } from "@/components/custom/date-range-picker";
 interface DataTableToolbarExtendedProps<Assignment> extends DataTableToolbarProps<Assignment> {
   allClients: ClientAndUserInterface[];
   allUsers: ClientAndUserInterface[];
+  allGroups: ClientAndUserInterface[];
   handlePrintClick: () => void;
   hasFullAccess?: boolean;
 }
@@ -41,6 +42,7 @@ export function DataTableToolbar<TData>({
   table,
   allClients,
   allUsers,
+  allGroups,
   handlePrintClick,
   hasFullAccess,
 }: DataTableToolbarExtendedProps<Assignment>) {
@@ -54,6 +56,7 @@ export function DataTableToolbar<TData>({
   const [selectedProject, setSelectedProject] = useQueryState("project");
   const [selectedClients, setSelectedClients] = useQueryState("clients");
   const [selectedMembers, setSelectedMembers] = useQueryState("members");
+  const [selectedGroups, setSelectedGroups] = useQueryState("groups");
 
   const clientFilter = {
     title: "Clients",
@@ -69,8 +72,15 @@ export function DataTableToolbar<TData>({
     options: allUsers,
   };
 
+  const groupFilter = {
+    title: "Groups",
+    searchable: true,
+    icon: <Tags size={16} />,
+    options: allGroups,
+  };
+
   const isResetButtonVisibile =
-    selectedRange || selectedBilling || selectedProject || selectedClients || selectedMembers;
+    selectedRange || selectedBilling || selectedProject || selectedClients || selectedMembers || selectedGroups;
 
   const generateBillingQuery = () => {
     if (!selectedBilling) return { text: "Hours", nextValue: "true" };
@@ -90,6 +100,7 @@ export function DataTableToolbar<TData>({
           selectedProject: Array.isArray(selectedProject) ? selectedProject.join(",") : selectedProject,
           selectedClients: Array.isArray(selectedClients) ? selectedClients.join(",") : selectedClients,
           selectedMembers: Array.isArray(selectedMembers) ? selectedMembers.join(",") : selectedMembers,
+          selectedGroups: Array.isArray(selectedGroups) ? selectedGroups.join(",") : selectedGroups,
         }),
       });
 
@@ -147,6 +158,7 @@ export function DataTableToolbar<TData>({
     setSelectedProject(null);
     setSelectedClients(null);
     setSelectedMembers(null);
+    setSelectedGroups(null);
   };
 
   return (
@@ -179,6 +191,9 @@ export function DataTableToolbar<TData>({
             </li>
             <li>
               <MultiSelectFilter values={peopleFilter} />
+            </li>
+            <li>
+              <MultiSelectFilter values={groupFilter} />
             </li>
           </>
         )}

--- a/app/[team]/members/page.tsx
+++ b/app/[team]/members/page.tsx
@@ -22,15 +22,16 @@ const ManageMembers = async (props: pageProps) => {
   const user = await getCurrentUser();
   const workspaceRole = getUserRole(user?.workspaces, team);
   const hasAccess = checkAccess(workspaceRole);
-  const groupParam = searchParams.group;
+  const { group: groupParam, status } = searchParams;
   const parsedGroupId = groupParam ? Number.parseInt(groupParam, 10) : undefined;
   const groupId = parsedGroupId !== undefined && !Number.isNaN(parsedGroupId) ? parsedGroupId : undefined;
+  const includeInactive = status === "all";
 
   if (!hasAccess) {
     return notFound();
   }
 
-  const data = await getMembers(team, groupId);
+  const data = await getMembers(team, groupId, includeInactive);
   const userGroup = await getGroups(team);
 
   return (

--- a/app/[team]/members/toolbar.tsx
+++ b/app/[team]/members/toolbar.tsx
@@ -1,14 +1,34 @@
 "use client";
 
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ListRestart } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { roles } from "@/config/filters";
 import { DataTableFacetedFilter } from "@/components/data-table/faceted-filter";
-import { ListRestart } from "lucide-react";
 import { DataTableToolbarProps } from "@/types";
 
 export function DataTableToolbar<TData>({ table }: DataTableToolbarProps<TData>) {
-  const isFiltered = table.getState().columnFilters.length > 0;
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const status = searchParams.get("status");
+  const group = searchParams.get("group");
+
+  const isFiltered = table.getState().columnFilters.length > 0 || status || group;
+
+  const handleShowInactive = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = e.currentTarget.checked;
+    router.push(
+      pathname +
+        "?" +
+        new URLSearchParams({
+          ...(isChecked && { status: "all" }),
+          ...(group && { group }),
+        }),
+    );
+  };
 
   return (
     <div className="flex items-center justify-between gap-x-3 rounded-xl border border-dashed p-2">
@@ -22,8 +42,27 @@ export function DataTableToolbar<TData>({ table }: DataTableToolbarProps<TData>)
         {table.getColumn("role") && (
           <DataTableFacetedFilter column={table.getColumn("role")} title="Role" options={roles} />
         )}
+        <div className="flex items-center space-x-2 select-none">
+          <input
+            type="checkbox"
+            id="inactive"
+            className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-4 w-4 cursor-pointer rounded-md border p-0 text-sm accent-current file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+            onChange={handleShowInactive}
+            checked={status === "all"}
+          />
+          <label htmlFor="inactive" className="cursor-pointer text-sm leading-none font-medium">
+            Show inactive members
+          </label>
+        </div>
         {isFiltered && (
-          <Button variant="ghost" onClick={() => table.resetColumnFilters()} className="h-8 px-2 lg:px-3">
+          <Button
+            variant="ghost"
+            onClick={() => {
+              table.resetColumnFilters();
+              router.push("?");
+            }}
+            className="h-8 px-2 lg:px-3"
+          >
             Reset
             <ListRestart className="ml-2 h-4 w-4" />
           </Button>

--- a/app/[team]/projects/[project]/(projects)/reports/matrix.tsx
+++ b/app/[team]/projects/[project]/(projects)/reports/matrix.tsx
@@ -62,54 +62,54 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
 
   const columns = useMemo<ColumnDef<MatrixRow>[]>(
     () => [
-    {
-      id: "name",
-      header: "Category / Task",
-      cell: ({ row }) => {
-        const canExpand = row.getCanExpand();
-        return (
-          <div className="flex items-center gap-2" style={{ paddingLeft: `${row.depth * 24}px` }}>
-            {canExpand ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-6 w-6 shrink-0 p-0"
-                onClick={row.getToggleExpandedHandler()}
-              >
-                {row.getIsExpanded() ? <Minus size={14} /> : <Plus size={14} />}
-              </Button>
-            ) : (
-              <span className="w-6 shrink-0" />
-            )}
-            <span className={cn("line-clamp-1", row.depth === 0 ? "font-medium" : "text-muted-foreground")}>
-              {row.original.name}
-            </span>
-          </div>
-        );
+      {
+        id: "name",
+        header: "Category / Task",
+        cell: ({ row }) => {
+          const canExpand = row.getCanExpand();
+          return (
+            <div className="flex items-center gap-2" style={{ paddingLeft: `${row.depth * 24}px` }}>
+              {canExpand ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-6 w-6 shrink-0 p-0"
+                  onClick={row.getToggleExpandedHandler()}
+                >
+                  {row.getIsExpanded() ? <Minus size={14} /> : <Plus size={14} />}
+                </Button>
+              ) : (
+                <span className="w-6 shrink-0" />
+              )}
+              <span className={cn("line-clamp-1", row.depth === 0 ? "font-medium" : "text-muted-foreground")}>
+                {row.original.name}
+              </span>
+            </div>
+          );
+        },
       },
-    },
-    ...data.members.map<ColumnDef<MatrixRow>>((member) => ({
-      id: `member-${member.id}`,
-      header: () => (
-        <span className="block text-right" title={member.name ?? undefined}>
-          {firstName(member.name)}
-        </span>
-      ),
-      cell: ({ row }) => (
-        <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
-          {format(row.original.cells[member.id])}
-        </span>
-      ),
-    })),
-    {
-      id: "total",
-      header: () => <span className="block text-right font-semibold">Total</span>,
-      cell: ({ row }) => (
-        <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
-          {format(row.original.total)}
-        </span>
-      ),
-    },
+      ...data.members.map<ColumnDef<MatrixRow>>((member) => ({
+        id: `member-${member.id}`,
+        header: () => (
+          <span className="block text-right" title={member.name ?? undefined}>
+            {firstName(member.name)}
+          </span>
+        ),
+        cell: ({ row }) => (
+          <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
+            {format(row.original.cells[member.id])}
+          </span>
+        ),
+      })),
+      {
+        id: "total",
+        header: () => <span className="block text-right font-semibold">Total</span>,
+        cell: ({ row }) => (
+          <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
+            {format(row.original.total)}
+          </span>
+        ),
+      },
     ],
     [data.members, format],
   );
@@ -126,7 +126,7 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
 
   if (data.members.length === 0) {
     return (
-      <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+      <p className="text-muted-foreground rounded-md border border-dashed p-6 text-center text-sm">
         No time logged in the selected period.
       </p>
     );
@@ -153,41 +153,39 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id} className={header.id === "name" ? "min-w-[240px]" : ""}>
-                    {flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id} className={row.depth === 0 ? "bg-muted/50" : ""}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-          <TableFooter>
-            <TableRow className="font-semibold">
-              <TableCell>Total</TableCell>
-              {data.members.map((member) => (
-                <TableCell key={member.id} className="text-right tabular-nums">
-                  {format(data.memberTotals[member.id])}
-                </TableCell>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} className={header.id === "name" ? "min-w-[240px]" : ""}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
               ))}
-              <TableCell className="text-right tabular-nums">{format(data.grandTotal)}</TableCell>
             </TableRow>
-          </TableFooter>
-        </Table>
-      </div>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id} className={row.depth === 0 ? "bg-muted/50" : ""}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow className="font-semibold">
+            <TableCell>Total</TableCell>
+            {data.members.map((member) => (
+              <TableCell key={member.id} className="text-right tabular-nums">
+                {format(data.memberTotals[member.id])}
+              </TableCell>
+            ))}
+            <TableCell className="text-right tabular-nums">{format(data.grandTotal)}</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
     </div>
   );
 }

--- a/app/[team]/projects/[project]/(projects)/reports/matrix.tsx
+++ b/app/[team]/projects/[project]/(projects)/reports/matrix.tsx
@@ -14,6 +14,7 @@ import { Minus, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type Cells = Record<number, number>;
 
@@ -34,6 +35,12 @@ type MatrixRow = { id: string; name: string; total: number; cells: Cells; subRow
 
 const firstName = (name: string | null) => name?.trim().split(/\s+/)[0] ?? "—";
 
+const stickyFirstColWidth = "w-[260px] min-w-[260px] max-w-[260px]";
+const stickyFirstCol = "sticky left-0 z-[2] border-r border-border bg-background";
+const stickyFirstColMuted = "sticky left-0 z-[2] border-r border-border bg-muted";
+const stickyFirstColHeader = "sticky left-0 z-[3] border-r border-border bg-background";
+const dataCell = "whitespace-nowrap px-3 tabular-nums";
+
 export function ProjectMatrix({ data }: { data: MatrixData }) {
   const [mode, setMode] = useState<"hours" | "percent">("percent");
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -41,7 +48,7 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
   const format = useCallback(
     (value?: number) => {
       if (!value) return "—";
-      if (mode === "hours") return `${value} h`;
+      if (mode === "hours") return `${value}\u00a0h`;
       if (!data.grandTotal) return "—";
       return `${Math.round((value / data.grandTotal) * 100)}%`;
     },
@@ -68,7 +75,7 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
         cell: ({ row }) => {
           const canExpand = row.getCanExpand();
           return (
-            <div className="flex items-center gap-2" style={{ paddingLeft: `${row.depth * 24}px` }}>
+            <div className="flex min-w-0 items-center gap-2" style={{ paddingLeft: `${row.depth * 24}px` }}>
               {canExpand ? (
                 <Button
                   variant="outline"
@@ -81,9 +88,16 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
               ) : (
                 <span className="w-6 shrink-0" />
               )}
-              <span className={cn("line-clamp-1", row.depth === 0 ? "font-medium" : "text-muted-foreground")}>
-                {row.original.name}
-              </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={cn("min-w-0 flex-1 truncate", row.depth === 0 ? "font-medium" : "text-muted-foreground")}
+                  >
+                    {row.original.name}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right">{row.original.name}</TooltipContent>
+              </Tooltip>
             </div>
           );
         },
@@ -91,21 +105,21 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
       ...data.members.map<ColumnDef<MatrixRow>>((member) => ({
         id: `member-${member.id}`,
         header: () => (
-          <span className="block text-right" title={member.name ?? undefined}>
+          <span className="block text-right whitespace-nowrap" title={member.name ?? undefined}>
             {firstName(member.name)}
           </span>
         ),
         cell: ({ row }) => (
-          <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
+          <span className={cn("block text-right", row.depth > 0 && "text-muted-foreground")}>
             {format(row.original.cells[member.id])}
           </span>
         ),
       })),
       {
         id: "total",
-        header: () => <span className="block text-right font-semibold">Total</span>,
+        header: () => <span className="block text-right font-semibold whitespace-nowrap">Total</span>,
         cell: ({ row }) => (
-          <span className={cn("block text-right tabular-nums", row.depth > 0 && "text-muted-foreground")}>
+          <span className={cn("block text-right", row.depth > 0 && "text-muted-foreground")}>
             {format(row.original.total)}
           </span>
         ),
@@ -114,6 +128,7 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
     [data.members, format],
   );
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: rows,
     columns,
@@ -153,12 +168,20 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
         </div>
       </div>
 
-      <Table>
+      <Table className="w-max min-w-full border-separate border-spacing-0">
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id} className={header.id === "name" ? "min-w-[240px]" : ""}>
+                <TableHead
+                  key={header.id}
+                  className={cn(
+                    dataCell,
+                    header.id === "name"
+                      ? cn(stickyFirstColWidth, stickyFirstColHeader, "pr-4 text-left whitespace-nowrap")
+                      : "min-w-18 text-right",
+                  )}
+                >
                   {flexRender(header.column.columnDef.header, header.getContext())}
                 </TableHead>
               ))}
@@ -167,22 +190,38 @@ export function ProjectMatrix({ data }: { data: MatrixData }) {
         </TableHeader>
         <TableBody>
           {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id} className={row.depth === 0 ? "bg-muted/50" : ""}>
+            <TableRow key={row.id} className={row.depth === 0 ? "bg-muted/50" : "bg-background"}>
               {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                <TableCell
+                  key={cell.id}
+                  className={cn(
+                    dataCell,
+                    cell.column.id === "name"
+                      ? cn(
+                          stickyFirstColWidth,
+                          row.depth === 0 ? stickyFirstColMuted : stickyFirstCol,
+                          "overflow-hidden pr-4 text-left",
+                        )
+                      : cn(dataCell, "min-w-18 text-right"),
+                  )}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
               ))}
             </TableRow>
           ))}
         </TableBody>
         <TableFooter>
-          <TableRow className="font-semibold">
-            <TableCell>Total</TableCell>
+          <TableRow className="bg-muted font-semibold">
+            <TableCell className={cn(dataCell, stickyFirstColWidth, stickyFirstColMuted, "pr-4 whitespace-nowrap")}>
+              Total
+            </TableCell>
             {data.members.map((member) => (
-              <TableCell key={member.id} className="text-right tabular-nums">
+              <TableCell key={member.id} className={cn(dataCell, "min-w-18 text-right")}>
                 {format(data.memberTotals[member.id])}
               </TableCell>
             ))}
-            <TableCell className="text-right tabular-nums">{format(data.grandTotal)}</TableCell>
+            <TableCell className={cn(dataCell, "min-w-18 text-right")}>{format(data.grandTotal)}</TableCell>
           </TableRow>
         </TableFooter>
       </Table>

--- a/app/[team]/projects/[project]/(projects)/reports/page.tsx
+++ b/app/[team]/projects/[project]/(projects)/reports/page.tsx
@@ -48,7 +48,7 @@ export default async function Page(props: pageProps) {
   const isBillable = projectDetails?.billable ?? false;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col">
       <DataTableToolbar
         isBillable={isBillable}
         allMembers={allMembers}

--- a/app/[team]/projects/[project]/components/columns.tsx
+++ b/app/[team]/projects/[project]/components/columns.tsx
@@ -95,11 +95,16 @@ export const getColumns = (
             {depth === 1 && (
               <span className="flex items-center gap-2 md:inline-flex">
                 {showTask && row.original.task?.name && (
-                  <Badge variant="secondary" className="shrink-0 font-normal">
+                  <Badge
+                    variant="secondary"
+                    className="inline-flex shrink-0 items-center font-normal"
+                    title={`Task: ${row.original.task.name}`}
+                  >
+                    <List size={12} className="mr-1 shrink-0" />
                     {row.original.task.name}
                   </Badge>
                 )}
-                <span className="ml-2 line-clamp-1 opacity-50" title={row.original.comments}>
+                <span className="line-clamp-1 opacity-50" title={row.original.comments}>
                   {row.original?.comments ?? ""}
                 </span>
               </span>
@@ -118,15 +123,7 @@ export const getColumns = (
   },
 ];
 
-function TimeEntryCell({
-  row,
-  categories,
-  tasks,
-}: {
-  row: any;
-  categories: SelectOption[];
-  tasks: SelectOption[];
-}) {
+function TimeEntryCell({ row, categories, tasks }: { row: any; categories: SelectOption[]; tasks: SelectOption[] }) {
   const { depth, original } = row;
   const params = useParams();
   const router = useRouter();
@@ -139,11 +136,7 @@ function TimeEntryCell({
   const [task, setTask] = useState<SelectOption | null>(null);
   const formatted = `${row.getValue("hours") ?? 0} h`;
 
-  const dropdownSelectHandler = (
-    selected: string,
-    options: SelectOption[],
-    callback: (item: SelectOption) => void,
-  ) => {
+  const dropdownSelectHandler = (selected: string, options: SelectOption[], callback: (item: SelectOption) => void) => {
     const found = options.find((option) => option.id === +selected);
     if (found) callback(found);
   };
@@ -222,11 +215,11 @@ function TimeEntryCell({
       <span className={`group relative mr-4 inline-block w-20 text-right ${depth === 0 ? "font-semibold" : ""}`}>
         <span className={`${depth > 0 ? "opacity-50" : ""} mr-1`}>{formatted}</span>
         {original.billable && (
-          <Circle className="absolute -right-3 top-1/2 h-2.5 w-2.5 -translate-y-1/2 fill-success stroke-none sm:-right-3.5 md:-right-4" />
+          <Circle className="fill-success absolute top-1/2 -right-3 h-2.5 w-2.5 -translate-y-1/2 stroke-none sm:-right-3.5 md:-right-4" />
         )}
       </span>
       {depth > 0 && (
-        <div className="absolute bottom-0 right-20 top-0 mr-4 hidden items-center justify-center gap-2 group-hover:flex">
+        <div className="absolute top-0 right-20 bottom-0 mr-4 hidden items-center justify-center gap-2 group-hover:flex">
           <Dialog>
             <DialogTrigger asChild>
               <Button
@@ -318,7 +311,7 @@ function TimeEntryCell({
           </Dialog>
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="ghost" className="h-6 w-6 p-0 text-destructive">
+              <Button variant="ghost" className="text-destructive h-6 w-6 p-0">
                 <Trash size={12} />
               </Button>
             </DialogTrigger>

--- a/app/[team]/projects/[project]/components/multiselect-filters.tsx
+++ b/app/[team]/projects/[project]/components/multiselect-filters.tsx
@@ -14,10 +14,8 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { ClientAndUserInterface } from "./data-table";
 
@@ -115,7 +113,9 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
           {values.title}
           {selectedOptions.length > 0 && (
             <>
-              <Separator orientation="vertical" className="h-4" />
+              <span className="flex self-stretch items-center" aria-hidden="true">
+                <span className="bg-border h-4 w-px shrink-0" />
+              </span>
               <Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
                 {selectedOptions.length}
               </Badge>
@@ -139,32 +139,29 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
-        <Command>
+        <Command className="overflow-hidden">
           {values.searchable && <CommandInput placeholder="Search..." />}
-          <CommandEmpty>No options found.</CommandEmpty>
-          <CommandList>
+          <CommandList className="max-h-[250px]">
+            <CommandEmpty>No options found.</CommandEmpty>
             <CommandGroup heading={hasArchived ? "Active" : undefined}>{activeOptions.map(renderItem)}</CommandGroup>
             {archivedOptions.length > 0 && (
               <CommandGroup heading={values.archivedLabel ?? "Archived"}>{archivedOptions.map(renderItem)}</CommandGroup>
             )}
-            {selectedOptions.length > 0 && (
-              <>
-                <CommandSeparator />
-                <CommandGroup>
-                  <CommandItem
-                    onSelect={() => {
-                      setSelectedOptions([]);
-                      setOpen(false);
-                      router.push(pathname + "?" + createQueryString(isFilterOf, ""));
-                    }}
-                    className="cursor-pointer justify-center text-center"
-                  >
-                    Clear filters
-                  </CommandItem>
-                </CommandGroup>
-              </>
-            )}
           </CommandList>
+          {selectedOptions.length > 0 && (
+            <div className="border-t bg-popover p-1">
+              <CommandItem
+                onSelect={() => {
+                  setSelectedOptions([]);
+                  setOpen(false);
+                  router.push(pathname + "?" + createQueryString(isFilterOf, ""));
+                }}
+                className="cursor-pointer justify-center text-center"
+              >
+                Clear filters
+              </CommandItem>
+            </div>
+          )}
         </Command>
       </PopoverContent>
     </Popover>

--- a/app/[team]/projects/[project]/components/time-chart.tsx
+++ b/app/[team]/projects/[project]/components/time-chart.tsx
@@ -4,11 +4,10 @@ import { eachMonthOfInterval, endOfMonth, format, startOfDay, startOfMonth, subD
 import React from "react";
 import { XAxis, YAxis, Tooltip, ResponsiveContainer, Bar, BarChart } from "recharts";
 
+import { Clock } from "lucide-react";
+
 import { Card, CardHeader } from "@/components/ui/card";
 import { getTimeInHours } from "@/lib/helper";
-import { Info } from "lucide-react";
-
-import { CustomTooltip as CustomTooltipUI } from "@/components/custom/tooltip";
 
 const DAILY_CHART_MAX_DAYS = 31;
 
@@ -132,11 +131,13 @@ const TimeChart = ({ timeEntries, totalDays, startDate, endDate }: TimeChartProp
     <Card className="p-0 shadow-none select-none">
       <CardHeader className="mt-2 flex flex-row items-center justify-between px-4 py-2">
         <p className="font-semibold">{isMonthlyView ? "Month-wise distribution" : "Day-wise distribution"}</p>
-        <CustomTooltipUI
-          content={`Total: ${totalTime} hours`}
-          trigger={<Info size={16} className="text-muted-foreground" />}
-          sideOffset={10}
-        />
+        <p className="flex items-center gap-1.5 text-base leading-none font-semibold tabular-nums">
+          <Clock size={16} className="shrink-0" />
+          <span>
+            {totalTime}
+            <span className="text-sm font-normal">h</span>
+          </span>
+        </p>
       </CardHeader>
       <div className="flex h-[200px] items-end justify-end py-2 pr-8 sm:h-[300px] md:h-[416px]">
         <ResponsiveContainer width="100%" height="100%">

--- a/app/[team]/projects/[project]/components/toolbar.tsx
+++ b/app/[team]/projects/[project]/components/toolbar.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { format, startOfDay, startOfMonth, startOfToday } from "date-fns";
-import { CircleDollarSign, Download, Layers, ListChecks, ListRestart, Loader2, Users } from "lucide-react";
+import { CircleDollarSign, Download, List, ListRestart, Loader2, Milestone, Users } from "lucide-react";
 import csvDownload from "json-to-csv-export";
 
 import { cn } from "@/lib/utils";
@@ -59,14 +59,14 @@ export function DataTableToolbar({
   const categoryFilter = {
     title: "Category",
     searchable: true,
-    icon: <Layers size={16} />,
+    icon: <Milestone size={16} />,
     options: allCategories,
   };
 
   const taskFilter = {
     title: "Task",
     searchable: true,
-    icon: <ListChecks size={16} />,
+    icon: <List size={16} />,
     options: allTasks,
   };
 

--- a/app/[team]/projects/[project]/components/user-details.tsx
+++ b/app/[team]/projects/[project]/components/user-details.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import React from "react";
-
 import { DataTable } from "./data-table";
 import { getColumns } from "./columns";
 import { ProjectSelectOption } from "./project-edit-combobox";

--- a/app/[team]/projects/multiselect-filters.tsx
+++ b/app/[team]/projects/multiselect-filters.tsx
@@ -14,10 +14,8 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 
 interface ClientAndUserInterface {
@@ -90,7 +88,9 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
           {values.title}
           {selectedOptions.length > 0 && (
             <>
-              <Separator orientation="vertical" className="h-4" />
+              <span className="flex self-stretch items-center" aria-hidden="true">
+                <span className="bg-border h-4 w-px shrink-0" />
+              </span>
               <Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
                 {selectedOptions.length}
               </Badge>
@@ -114,11 +114,11 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
-        <Command>
+        <Command className="overflow-hidden">
           {values.searchable && <CommandInput placeholder="Search..." />}
-          <CommandEmpty>No options found.</CommandEmpty>
-          <CommandGroup>
-            <CommandList>
+          <CommandList className="max-h-[250px]">
+            <CommandEmpty>No options found.</CommandEmpty>
+            <CommandGroup>
               {values.options.map((option) => {
                 const isSelected = selectedOptions.includes(`${option.id}`);
                 return (
@@ -142,24 +142,21 @@ const MultiSelectFilter = ({ values }: { values: DropdownInterface }) => {
                   </CommandItem>
                 );
               })}
-            </CommandList>
-          </CommandGroup>
+            </CommandGroup>
+          </CommandList>
           {selectedOptions.length > 0 && (
-            <>
-              <CommandSeparator />
-              <CommandGroup>
-                <CommandItem
-                  onSelect={() => {
-                    setSelectedOptions([]);
-                    setOpen(false);
-                    router.push(pathname + "?" + createQueryString(isFilterOf, ""));
-                  }}
-                  className="cursor-pointer justify-center text-center"
-                >
-                  Clear filters
-                </CommandItem>
-              </CommandGroup>
-            </>
+            <div className="border-t bg-popover p-1">
+              <CommandItem
+                onSelect={() => {
+                  setSelectedOptions([]);
+                  setOpen(false);
+                  router.push(pathname + "?" + createQueryString(isFilterOf, ""));
+                }}
+                className="cursor-pointer justify-center text-center"
+              >
+                Clear filters
+              </CommandItem>
+            </div>
           )}
         </Command>
       </PopoverContent>

--- a/app/api/team/export/route.ts
+++ b/app/api/team/export/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
 
     const { user } = session;
 
-    const { slug, selectedRange, selectedBilling, selectedClients, selectedMembers, selectedProject, defaultDay } =
+    const { slug, selectedRange, selectedBilling, selectedClients, selectedMembers, selectedGroups, selectedProject, defaultDay } =
       data;
     const { startDate, endDate } = getStartandEndDates(selectedRange, defaultDay);
     const isBillable = stringToBoolean(selectedBilling);
@@ -62,6 +62,20 @@ export async function POST(req: NextRequest) {
         ...(selectedMembers && {
           userId: {
             in: selectedMembers.split(",").map((id: number) => +id),
+          },
+        }),
+        ...(selectedGroups && {
+          user: {
+            userOnGroup: {
+              some: {
+                groupId: {
+                  in: selectedGroups.split(",").map((id: number) => +id),
+                },
+                workspace: {
+                  slug,
+                },
+              },
+            },
           },
         }),
         ...(!hasFullAccess &&

--- a/components/data-table/faceted-filter.tsx
+++ b/components/data-table/faceted-filter.tsx
@@ -11,7 +11,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
@@ -67,9 +66,9 @@ export function DataTableFacetedFilter<TData, TValue>({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
-        <Command>
+        <Command className="overflow-hidden">
           <CommandInput placeholder={title} />
-          <CommandList>
+          <CommandList className="max-h-[250px]">
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup>
               {options.map((option) => {
@@ -106,20 +105,17 @@ export function DataTableFacetedFilter<TData, TValue>({
                 );
               })}
             </CommandGroup>
-            {selectedValues.size > 0 && (
-              <>
-                <CommandSeparator />
-                <CommandGroup>
-                  <CommandItem
-                    onSelect={() => column?.setFilterValue(undefined)}
-                    className="justify-center text-center"
-                  >
-                    Clear filters
-                  </CommandItem>
-                </CommandGroup>
-              </>
-            )}
           </CommandList>
+          {selectedValues.size > 0 && (
+            <div className="border-t bg-popover p-1">
+              <CommandItem
+                onSelect={() => column?.setFilterValue(undefined)}
+                className="justify-center text-center"
+              >
+                Clear filters
+              </CommandItem>
+            </div>
+          )}
         </Command>
       </PopoverContent>
     </Popover>

--- a/components/inline-select.tsx
+++ b/components/inline-select.tsx
@@ -10,7 +10,6 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
@@ -80,9 +79,9 @@ export function InlineSelect<TData, TValue>({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[200px] p-0" align="start">
-        <Command>
+        <Command className="overflow-hidden">
           <CommandInput placeholder={`Search ${title}`} />
-          <CommandList>
+          <CommandList className="max-h-[250px]">
             <CommandEmpty>No {title} found.</CommandEmpty>
             <CommandGroup>
               {options.map((option) => {
@@ -102,17 +101,14 @@ export function InlineSelect<TData, TValue>({
                 );
               })}
             </CommandGroup>
-            {isValueUpdated && (
-              <>
-                <CommandSeparator />
-                <CommandGroup>
-                  <CommandItem className="justify-center text-center" onSelect={() => onSelect(selected)}>
-                    Update
-                  </CommandItem>
-                </CommandGroup>
-              </>
-            )}
           </CommandList>
+          {isValueUpdated && (
+            <div className="border-t bg-popover p-1">
+              <CommandItem className="justify-center text-center" onSelect={() => onSelect(selected)}>
+                Update
+              </CommandItem>
+            </div>
+          )}
         </Command>
       </PopoverContent>
     </Popover>

--- a/server/services/members.ts
+++ b/server/services/members.ts
@@ -1,9 +1,12 @@
 import { db } from "@/server/db";
 
-export const getMembers = async (team: string, groupId?: number) => {
+export const getMembers = async (team: string, groupId?: number, includeInactive: boolean = true) => {
   const membersList = await db.userWorkspace.findMany({
     where: {
       workspace: { slug: team },
+      ...(!includeInactive && {
+        role: { not: "INACTIVE" },
+      }),
       ...(groupId && {
         user: {
           userOnGroup: {

--- a/server/services/time-entry.ts
+++ b/server/services/time-entry.ts
@@ -126,6 +126,7 @@ export const getLogged = async (
   project?: string,
   clients?: string,
   members?: string,
+  groups?: string,
   hasFullAccess?: boolean,
 ) => {
   const session = await getServerSession(authOptions);
@@ -172,6 +173,42 @@ export const getLogged = async (
       })
     : [];
 
+  const allGroups = hasFullAccess
+    ? await db.group.findMany({
+        where: {
+          workspace: {
+            slug: slug,
+          },
+        },
+        select: {
+          id: true,
+          name: true,
+        },
+        orderBy: {
+          name: "asc",
+        },
+      })
+    : [];
+
+  const selectedGroupIds = groups?.split(",").map((id) => +id) ?? [];
+  const groupUserFilter =
+    selectedGroupIds.length > 0
+      ? {
+          user: {
+            userOnGroup: {
+              some: {
+                groupId: {
+                  in: selectedGroupIds,
+                },
+                workspace: {
+                  slug: slug,
+                },
+              },
+            },
+          },
+        }
+      : {};
+
   const query = await db.client.findMany({
     where: {
       workspace: {
@@ -182,14 +219,17 @@ export const getLogged = async (
           in: clients.split(",").map((id) => +id),
         },
       }),
-      ...(members && {
+      ...((members || selectedGroupIds.length > 0) && {
         project: {
           some: {
             usersOnProject: {
               some: {
-                userId: {
-                  in: members?.split(",").map((id) => +id),
-                },
+                ...(members && {
+                  userId: {
+                    in: members.split(",").map((id) => +id),
+                  },
+                }),
+                ...groupUserFilter,
               },
             },
           },
@@ -236,6 +276,7 @@ export const getLogged = async (
                   in: members?.split(",").map((id) => +id),
                 },
               }),
+              ...(selectedGroupIds.length > 0 && groupUserFilter),
               ...(!hasFullAccess &&
                 loggedUserId && {
                   userId: {
@@ -249,6 +290,21 @@ export const getLogged = async (
                   id: true,
                   name: true,
                   image: true,
+                  userOnGroup: {
+                    where: {
+                      workspace: {
+                        slug: slug,
+                      },
+                    },
+                    select: {
+                      group: {
+                        select: {
+                          id: true,
+                          name: true,
+                        },
+                      },
+                    },
+                  },
                   timeEntry: {
                     where: {
                       date: {
@@ -316,6 +372,7 @@ export const getLogged = async (
               userId: user.user.id,
               userName: user.user.name,
               userImage: user.user.image,
+              userGroups: user.user.userOnGroup.map((userGroup) => userGroup.group),
               userHours:
                 +`${timeEntryBasedOnProject.reduce((sum, entry) => (sum += getTimeInHours(entry.time)), 0).toFixed(2)}`,
               userTimeEntry: timeEntryBasedOnProject.map((timeEntry) => {
@@ -341,5 +398,5 @@ export const getLogged = async (
     };
   });
 
-  return { data: response, allClients, allUsers };
+  return { data: response, allClients, allUsers, allGroups };
 };


### PR DESCRIPTION
## Summary
- Add a **Show inactive members** toggle on the Members page (inactive members hidden by default, matching the projects archive pattern).
- Enhance the **Logged Hours** report with a groups filter, member group badges (sky blue pill with `+N` overflow), and task badges with list icons on entry rows.
- Update the **project overview** to show task badges with icons on time entries and align Category/Task filter icons with the table (`Milestone` / `List`).
- Extend `getLogged`, `getMembers`, and CSV export to support group-based filtering server-side.

## Test plan
- [x] Members page: confirm inactive members are hidden by default; toggle **Show inactive members** reveals them; Reset clears the toggle.
- [x] Logged Hours report: filter by group and verify only matching members appear; confirm group badge shows on member rows with tooltip for multiple groups.
- [x] Logged Hours report: verify task badge appears on entry rows with list icon; category pill is not shown on entries.
- [x] Project overview (`/projects/[id]`): verify task badge on entry rows; Category/Task toolbar filters use Milestone/List icons.
- [x] CSV export from Logged Hours respects the groups filter when applied.


Made with [Cursor](https://cursor.com)