### PR TITLE
feat: Kanban-style board view for time logging

### DIFF
--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -1,0 +1,555 @@
+"use client";
+
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  Check,
+  CircleDollarSign,
+  Folder,
+  List,
+  ListRestart,
+  MessageSquare,
+  Milestone as CategoryIcon,
+  Minus,
+  Plus,
+  Search,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Project, Milestone } from "@/types";
+import { EditReferenceObj } from "../time-entry";
+import { cn } from "@/lib/utils";
+import { hoursToDecimal } from "@/lib/helper";
+
+import type { SelectedData } from "./timelogForm";
+
+interface TimelogBoardProps {
+  projects: Project[];
+  edit: EditReferenceObj;
+  submitHandler: (e: FormEvent, clearForm: Function, selectedData?: SelectedData) => void;
+  recent: any;
+}
+
+type ErrorsObj = {
+  time?: boolean;
+};
+
+type ClientGroup = {
+  clientId: number | string;
+  clientName: string;
+  projects: Project[];
+};
+
+const initialDataState: SelectedData = {
+  client: undefined,
+  project: undefined,
+  milestone: null,
+  task: null,
+  comment: "",
+  time: "",
+  billable: false,
+};
+
+const TIME_CHIPS = [
+  { id: 1, title: "+15m", incrementBy: 0.25 },
+  { id: 2, title: "+30m", incrementBy: 0.5 },
+  { id: 3, title: "+1h", incrementBy: 1 },
+];
+
+export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogBoardProps) => {
+  const [selectedData, setSelectedData] = useState<SelectedData>(initialDataState);
+  const [projectMilestones, setProjectMilestones] = useState<Milestone[]>([]);
+  const [projectTasks, setprojectTasks] = useState<Milestone[]>([]);
+  const [errors, setErrors] = useState<ErrorsObj>({});
+  const [projectQuery, setProjectQuery] = useState("");
+  const [projectSearchOpen, setProjectSearchOpen] = useState(false);
+  const [categoryQuery, setCategoryQuery] = useState("");
+  const [categorySearchOpen, setCategorySearchOpen] = useState(false);
+  const [taskQuery, setTaskQuery] = useState("");
+  const [taskSearchOpen, setTaskSearchOpen] = useState(false);
+
+  const resetSearches = () => {
+    setProjectQuery("");
+    setProjectSearchOpen(false);
+    setCategoryQuery("");
+    setCategorySearchOpen(false);
+    setTaskQuery("");
+    setTaskSearchOpen(false);
+  };
+
+  const handleClearForm = () => {
+    setSelectedData(initialDataState);
+    setProjectMilestones([]);
+    setprojectTasks([]);
+    setErrors({});
+    resetSearches();
+  };
+
+  const formValidator = () => {
+    const { project, comment, time } = selectedData || {};
+    return project && comment?.trim().length && time && !errors?.time;
+  };
+
+  const handleLoggedTimeInput = (time: string) => {
+    const numberPattern = new RegExp(/^([1-9]\d*(\.|\:)\d{0,2}|0?(\.|\:)\d*[1-9]\d{0,2}|[1-9]\d{0,2})$/, "g");
+    numberPattern.test(time) ? setErrors({ ...errors, time: false }) : setErrors({ ...errors, time: true });
+    setSelectedData({ ...selectedData, time: time });
+  };
+
+  // Parse the current field value (accepts "1.5" or "1:30") into decimal hours
+  const currentHours = () => {
+    const value = +hoursToDecimal(selectedData.time || "0");
+    return isNaN(value) ? 0 : value;
+  };
+
+  // Format decimal hours back into clock time, e.g. 1.5 -> "1:30", 0.25 -> "0:15"
+  const hoursToClock = (decimal: number) => {
+    const totalMinutes = Math.round(decimal * 60);
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    return `${h}:${m.toString().padStart(2, "0")}`;
+  };
+
+  const commitTime = (next: number) => {
+    const value = Math.max(next, 0);
+    setSelectedData({ ...selectedData, time: hoursToClock(value) });
+    if (value > 0) setErrors({ ...errors, time: false });
+  };
+
+  /*
+   * handleTimeChip: literally add a chunk of time (used by the +15m/+30m/+1h chips)
+   */
+  const handleTimeChip = (timeVariation: number) => commitTime(currentHours() + timeVariation);
+
+  /*
+   * handleTimeStep: round to the NEXT (increase) or PREVIOUS (decrease) 30-min boundary.
+   * e.g. 1:15 + -> 1:30, 1:15 - -> 1:00. Already on a boundary -> full 30-min step.
+   */
+  const STEP = 0.5;
+  const handleTimeStep = (action: "increase" | "decrease") => {
+    const units = currentHours() / STEP;
+    const next =
+      action === "increase" ? (Math.floor(units + 1e-9) + 1) * STEP : (Math.ceil(units - 1e-9) - 1) * STEP;
+    commitTime(next);
+  };
+
+  /*
+   * projectCallback: called when a project card is clicked
+   */
+  const projectCallback = (selected: Project) => {
+    setSelectedData((prev) => ({
+      ...prev,
+      client: selected?.client,
+      project: { id: selected.id, name: selected?.name, billable: selected?.billable },
+      // reset the downstream selections whenever a different project is picked
+      milestone: selected.id !== prev.project?.id ? undefined : prev.milestone,
+      task: selected.id !== prev.project?.id ? undefined : prev.task,
+      billable: selected?.billable ? true : false,
+    }));
+    setProjectMilestones(selected?.milestone ?? []);
+    setprojectTasks(selected?.task ?? []);
+    // clear any open category/task search when switching projects
+    setCategoryQuery("");
+    setCategorySearchOpen(false);
+    setTaskQuery("");
+    setTaskSearchOpen(false);
+  };
+
+  /*
+   * milestoneCallback / taskCallback: clicking a selected chip again clears it (both are optional)
+   */
+  const milestoneCallback = (selected: Milestone) =>
+    setSelectedData((prev) => ({ ...prev, milestone: prev.milestone?.id === selected.id ? null : selected }));
+
+  const taskCallback = (selected: Milestone) =>
+    setSelectedData((prev) => ({ ...prev, task: prev.task?.id === selected.id ? null : selected }));
+
+  const setCommentText = (str: string) => setSelectedData({ ...selectedData, comment: str });
+
+  // Keep the board in sync with edit / recent quick-fill flows (mirrors TimeLogForm)
+  useEffect(() => {
+    if (edit.isEditing) {
+      const foundProject = projects.find((project) => project.id === edit.obj.project?.id);
+      setSelectedData(edit.obj);
+      setProjectMilestones(foundProject?.milestone ?? []);
+      setprojectTasks(foundProject?.task ?? []);
+    } else if (recent) {
+      const foundProject = projects.find((project) => project.id === recent.project?.id);
+      setSelectedData(recent);
+      setProjectMilestones(foundProject?.milestone ?? []);
+      setprojectTasks(foundProject?.task ?? []);
+    } else {
+      handleClearForm();
+    }
+  }, [edit, projects, recent]);
+
+  // Group projects by client, then filter by the search box (mirrors ComboBox grouping)
+  const groupedProjects = useMemo<ClientGroup[]>(() => {
+    const query = projectQuery.trim().toLowerCase();
+    const grouped = Object.values(
+      projects.reduce((acc: Record<string, ClientGroup>, project) => {
+        const clientId = project.client?.id ?? "no-client";
+        const clientName = project.client?.name ?? "Other";
+        if (!acc[clientId]) acc[clientId] = { clientId, clientName, projects: [] };
+        acc[clientId].projects.push(project);
+        return acc;
+      }, {}),
+    ).sort((a, b) => a.clientName.localeCompare(b.clientName));
+
+    if (!query) return grouped;
+    return grouped
+      .map((group) => ({
+        ...group,
+        projects: group.projects.filter(
+          (project) =>
+            project.name?.toLowerCase().includes(query) || group.clientName.toLowerCase().includes(query),
+        ),
+      }))
+      .filter((group) => group.projects.length > 0);
+  }, [projects, projectQuery]);
+
+  const isProjectSelected = !!selectedData?.project?.id;
+  const hasSelection = selectedData?.project || selectedData?.task || selectedData?.milestone;
+
+  const filterByName = (items: Milestone[], query: string) => {
+    const q = query.trim().toLowerCase();
+    return q ? items.filter((item) => item.name?.toLowerCase().includes(q)) : items;
+  };
+  const filteredMilestones = useMemo(
+    () => filterByName(projectMilestones, categoryQuery),
+    [projectMilestones, categoryQuery],
+  );
+  const filteredTasks = useMemo(() => filterByName(projectTasks, taskQuery), [projectTasks, taskQuery]);
+
+  return (
+    <div className="p-2">
+      <div className="overflow-hidden rounded-xl border">
+        {/* Three cascading columns: Project -> Category -> Task */}
+        <div className="grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+          {/* Column 1: Projects (grouped by client) */}
+          <div className="flex min-w-0 flex-col">
+            <SearchableHeader
+              icon={<Folder size={14} className="shrink-0" />}
+              label="Project"
+              count={projects.length}
+              query={projectQuery}
+              setQuery={setProjectQuery}
+              open={projectSearchOpen}
+              setOpen={setProjectSearchOpen}
+            />
+            <ScrollArea className="h-[288px]">
+              <div className="p-1.5">
+                {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
+                {groupedProjects.map((group) => (
+                  <div key={group.clientId} className="mb-1">
+                    <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {group.clientName}
+                    </p>
+                    {group.projects.map((project) => (
+                      <BoardItem
+                        key={project.id}
+                        label={project.name}
+                        active={selectedData?.project?.id === project.id}
+                        onClick={() => projectCallback(project)}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
+
+          {/* Column 2: Categories (milestones) */}
+          <div className="flex min-w-0 flex-col">
+            <SearchableHeader
+              icon={<CategoryIcon size={14} className="shrink-0" />}
+              label="Category"
+              count={projectMilestones.length}
+              query={categoryQuery}
+              setQuery={setCategoryQuery}
+              open={categorySearchOpen}
+              setOpen={setCategorySearchOpen}
+              disabled={!isProjectSelected || projectMilestones.length === 0}
+            />
+            <ScrollArea className="h-[288px]">
+              <div className="p-1.5">
+                {!isProjectSelected ? (
+                  <EmptyState text="Pick a project first" />
+                ) : projectMilestones.length === 0 ? (
+                  <EmptyState text="No categories" />
+                ) : filteredMilestones.length === 0 ? (
+                  <EmptyState text="No matches" />
+                ) : (
+                  filteredMilestones.map((milestone) => (
+                    <BoardItem
+                      key={milestone.id}
+                      label={milestone.name}
+                      active={selectedData?.milestone?.id === milestone.id}
+                      onClick={() => milestoneCallback(milestone)}
+                    />
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+
+          {/* Column 3: Tasks */}
+          <div className="flex min-w-0 flex-col">
+            <SearchableHeader
+              icon={<List size={14} className="shrink-0" />}
+              label="Task"
+              count={projectTasks.length}
+              query={taskQuery}
+              setQuery={setTaskQuery}
+              open={taskSearchOpen}
+              setOpen={setTaskSearchOpen}
+              disabled={!isProjectSelected || projectTasks.length === 0}
+            />
+            <ScrollArea className="h-[288px]">
+              <div className="p-1.5">
+                {!isProjectSelected ? (
+                  <EmptyState text="Pick a project first" />
+                ) : projectTasks.length === 0 ? (
+                  <EmptyState text="No tasks" />
+                ) : filteredTasks.length === 0 ? (
+                  <EmptyState text="No matches" />
+                ) : (
+                  filteredTasks.map((task) => (
+                    <BoardItem
+                      key={task.id}
+                      label={task.name}
+                      active={selectedData?.task?.id === task.id}
+                      onClick={() => taskCallback(task)}
+                    />
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        </div>
+
+        {/* Compose bar: comment + time + billable + submit */}
+        <form
+          onSubmit={(e) => submitHandler(e, handleClearForm, selectedData)}
+          onKeyDown={(e) => e.key === "Enter" && formValidator() && submitHandler(e, handleClearForm, selectedData)}
+          autoComplete="off"
+          className="border-t bg-muted/30"
+        >
+          <div className="flex flex-col gap-2 p-2">
+            {/* Row 1: comment box — always editable to reduce friction */}
+            <div className="flex min-h-[52px] items-start rounded-md border bg-background px-2 py-2">
+              <MessageSquare className="mt-1 shrink-0 text-muted-foreground" size={16} />
+              <textarea
+                rows={2}
+                className="min-h-[36px] w-full resize-y border-0 bg-transparent px-2 py-0.5 text-sm focus:outline-0 focus:ring-0"
+                placeholder="Add a comment..."
+                value={selectedData?.comment ?? ""}
+                onChange={(e) => setCommentText(e.target.value)}
+                onKeyDown={(e) => {
+                  // Enter submits; Shift+Enter adds a newline.
+                  // Stop propagation so the form-level Enter handler doesn't also fire.
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    if (!e.shiftKey) {
+                      e.preventDefault();
+                      if (formValidator()) submitHandler(e as unknown as FormEvent, handleClearForm, selectedData);
+                    }
+                  }
+                }}
+              />
+            </div>
+
+            {/* Row 2: time controls + reset ... billable + submit */}
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Quick time chips — always available */}
+              <div className="flex items-center gap-1">
+                {TIME_CHIPS.map((chip) => (
+                  <Badge
+                    key={chip.id}
+                    variant="secondary"
+                    className="cursor-pointer rounded-full px-2 py-1 text-[11px]"
+                    onClick={() => handleTimeChip(chip.incrementBy)}
+                  >
+                    {chip.title}
+                  </Badge>
+                ))}
+              </div>
+
+              {/* Time stepper — always available (rounds to the next/prev 30 mins) */}
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  className="h-8 w-8 shrink-0 rounded-full"
+                  onClick={() => handleTimeStep("decrease")}
+                  disabled={errors.time || currentHours() <= 0}
+                  title="Round down to previous 30 mins"
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <Input
+                  type="text"
+                  placeholder="2:30"
+                  className={cn(
+                    errors?.time
+                      ? "border-destructive ring-1 ring-destructive focus:border-destructive focus:ring-destructive"
+                      : "border-border focus:border-primary focus:ring-primary",
+                    "h-9 w-[64px] select-none rounded-md border bg-background py-1 text-center text-sm leading-none",
+                  )}
+                  value={selectedData?.time ?? ""}
+                  onChange={(e) => handleLoggedTimeInput(e.currentTarget.value)}
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  className="h-8 w-8 shrink-0 rounded-full"
+                  onClick={() => handleTimeStep("increase")}
+                  title="Round up to next 30 mins"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+
+              {/* Reset — mildly destructive */}
+              {hasSelection && (
+                <Button
+                  variant="outline"
+                  size="icon"
+                  type="button"
+                  onClick={handleClearForm}
+                  className="shrink-0 border-destructive/30 text-destructive/70 hover:border-destructive hover:bg-destructive/10 hover:text-destructive"
+                  title="Reset form"
+                >
+                  <ListRestart size={16} />
+                </Button>
+              )}
+
+              {/* Billable + Submit grouped on the right */}
+              <div className="ml-auto flex items-center gap-2">
+                {selectedData.project?.billable && (
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    type="button"
+                    title="Toggle billable"
+                    onClick={() =>
+                      selectedData?.project?.billable &&
+                      setSelectedData((prev) => ({ ...prev, billable: !prev.billable }))
+                    }
+                    className={cn(
+                      "shrink-0",
+                      selectedData.billable
+                        ? "border-success bg-success text-white hover:bg-success hover:text-white"
+                        : "text-slate-400 hover:text-slate-400",
+                    )}
+                  >
+                    <CircleDollarSign size={18} />
+                  </Button>
+                )}
+
+                <Button size="sm" type="submit" disabled={!formValidator()} className="shrink-0">
+                  {edit.isEditing ? "Update" : "Submit"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+/* ---------- small presentational helpers ---------- */
+
+type SearchableHeaderProps = {
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+  query: string;
+  setQuery: (value: string) => void;
+  open: boolean;
+  setOpen: (value: boolean) => void;
+  disabled?: boolean;
+};
+
+const SearchableHeader = ({
+  icon,
+  label,
+  count,
+  query,
+  setQuery,
+  open,
+  setOpen,
+  disabled = false,
+}: SearchableHeaderProps) => {
+  const canSearch = !disabled;
+  const close = () => {
+    setQuery("");
+    setOpen(false);
+  };
+  return (
+    <div
+      className={cn(
+        "flex h-9 items-center gap-2 border-b bg-muted/40 px-3 text-xs font-medium text-muted-foreground",
+        !open && canSearch && "cursor-text hover:text-foreground",
+      )}
+      onClick={!open && canSearch ? () => setOpen(true) : undefined}
+      title={!open && canSearch ? `Click to search ${label.toLowerCase()}` : undefined}
+    >
+      {icon}
+      {open ? (
+        <>
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Escape" && close()}
+            placeholder={`Search ${label.toLowerCase()}...`}
+            className="w-full border-0 bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-0 focus:ring-0"
+          />
+          <button type="button" onClick={close} title="Close search" className="shrink-0 rounded p-0.5 hover:bg-muted">
+            <X size={13} />
+          </button>
+        </>
+      ) : (
+        <>
+          <span>{label}</span>
+          {count > 0 && <span className="text-[10px] tabular-nums">{count}</span>}
+          {canSearch && (
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              title={`Search ${label.toLowerCase()}`}
+              className="ml-auto shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
+            >
+              <Search size={13} />
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+const BoardItem = ({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+      active ? "bg-primary text-primary-foreground" : "hover:bg-muted",
+    )}
+  >
+    <span className="min-w-0 flex-1 truncate">{label}</span>
+    {active && <Check className="h-3.5 w-3.5 shrink-0" />}
+  </button>
+);
+
+const EmptyState = ({ text }: { text: string }) => (
+  <p className="px-2 py-6 text-center text-xs text-muted-foreground">{text}</p>
+);

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FormEvent, useEffect, useMemo, useState } from "react";
+import React, { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   CircleDollarSign,
@@ -31,6 +31,8 @@ interface TimelogBoardProps {
   edit: EditReferenceObj;
   submitHandler: (e: FormEvent, clearForm: Function, selectedData?: SelectedData) => void;
   recent: any;
+  draft?: SelectedData;
+  onDraftChange?: (draft: SelectedData) => void;
 }
 
 type ErrorsObj = {
@@ -59,7 +61,7 @@ const TIME_CHIPS = [
   { id: 3, title: "+1h", incrementBy: 1 },
 ];
 
-export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogBoardProps) => {
+export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onDraftChange }: TimelogBoardProps) => {
   const [selectedData, setSelectedData] = useState<SelectedData>(initialDataState);
   const [projectMilestones, setProjectMilestones] = useState<Milestone[]>([]);
   const [projectTasks, setprojectTasks] = useState<Milestone[]>([]);
@@ -169,22 +171,36 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogB
 
   const setCommentText = (str: string) => setSelectedData({ ...selectedData, comment: str });
 
-  // Keep the board in sync with edit / recent quick-fill flows (mirrors TimeLogForm)
+  // Seed local state from a SelectedData snapshot, deriving the project's category/task lists
+  const seedState = (data?: SelectedData | null) => {
+    const found = projects.find((project) => project.id === data?.project?.id);
+    setSelectedData(data && Object.keys(data).length ? data : initialDataState);
+    setProjectMilestones(found?.milestone ?? []);
+    setprojectTasks(found?.task ?? []);
+    setErrors({});
+  };
+
+  // Latest shared draft, read on mount/switch without re-running the effect on every keystroke
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
+  // Keep the board in sync with edit / recent quick-fill; otherwise seed from the shared draft
   useEffect(() => {
     if (edit.isEditing) {
-      const foundProject = projects.find((project) => project.id === edit.obj.project?.id);
-      setSelectedData(edit.obj);
-      setProjectMilestones(foundProject?.milestone ?? []);
-      setprojectTasks(foundProject?.task ?? []);
+      seedState(edit.obj);
     } else if (recent) {
-      const foundProject = projects.find((project) => project.id === recent.project?.id);
-      setSelectedData(recent);
-      setProjectMilestones(foundProject?.milestone ?? []);
-      setprojectTasks(foundProject?.task ?? []);
+      seedState(recent);
     } else {
-      handleClearForm();
+      seedState(draftRef.current);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edit, projects, recent]);
+
+  // Report the live draft up so the other view can pick it up (skip while editing/quick-fill)
+  useEffect(() => {
+    if (!edit.isEditing && !recent) onDraftChange?.(selectedData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedData, edit.isEditing, recent]);
 
   // Group projects by client, then filter by the search box (mirrors ComboBox grouping)
   const groupedProjects = useMemo<ClientGroup[]>(() => {
@@ -234,13 +250,12 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogB
             <SearchableHeader
               icon={<Folder size={14} className="shrink-0" />}
               label="Project"
-              count={projects.length}
               query={projectQuery}
               setQuery={setProjectQuery}
               open={projectSearchOpen}
               setOpen={setProjectSearchOpen}
             />
-            <ScrollArea className="h-[288px]">
+            <ScrollArea className="max-h-[240px] sm:h-[240px]">
               <div className="p-1.5">
                 {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
                 {groupedProjects.map((group) => (
@@ -267,14 +282,13 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogB
             <SearchableHeader
               icon={<CategoryIcon size={14} className="shrink-0" />}
               label="Category"
-              count={projectMilestones.length}
               query={categoryQuery}
               setQuery={setCategoryQuery}
               open={categorySearchOpen}
               setOpen={setCategorySearchOpen}
               disabled={!isProjectSelected || projectMilestones.length === 0}
             />
-            <ScrollArea className="h-[288px]">
+            <ScrollArea className="max-h-[240px] sm:h-[240px]">
               <div className="p-1.5">
                 {!isProjectSelected ? (
                   <EmptyState text="Pick a project first" />
@@ -301,14 +315,13 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogB
             <SearchableHeader
               icon={<List size={14} className="shrink-0" />}
               label="Task"
-              count={projectTasks.length}
               query={taskQuery}
               setQuery={setTaskQuery}
               open={taskSearchOpen}
               setOpen={setTaskSearchOpen}
               disabled={!isProjectSelected || projectTasks.length === 0}
             />
-            <ScrollArea className="h-[288px]">
+            <ScrollArea className="max-h-[240px] sm:h-[240px]">
               <div className="p-1.5">
                 {!isProjectSelected ? (
                   <EmptyState text="Pick a project first" />
@@ -469,7 +482,6 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent }: TimelogB
 type SearchableHeaderProps = {
   icon: React.ReactNode;
   label: string;
-  count: number;
   query: string;
   setQuery: (value: string) => void;
   open: boolean;
@@ -480,7 +492,6 @@ type SearchableHeaderProps = {
 const SearchableHeader = ({
   icon,
   label,
-  count,
   query,
   setQuery,
   open,
@@ -519,7 +530,6 @@ const SearchableHeader = ({
       ) : (
         <>
           <span>{label}</span>
-          {count > 0 && <span className="text-[10px] tabular-nums">{count}</span>}
           {canSearch && (
             <button
               type="button"
@@ -541,12 +551,12 @@ const BoardItem = ({ label, active, onClick }: { label: string; active: boolean;
     type="button"
     onClick={onClick}
     className={cn(
-      "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-      active ? "bg-primary text-primary-foreground" : "hover:bg-muted",
+      "flex w-full items-start justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+      active ? "bg-accent font-medium text-accent-foreground" : "hover:bg-muted",
     )}
   >
-    <span className="min-w-0 flex-1 truncate">{label}</span>
-    {active && <Check className="h-3.5 w-3.5 shrink-0" />}
+    <span className="min-w-0 flex-1 break-words">{label}</span>
+    <Check className={cn("mt-0.5 h-3.5 w-3.5 shrink-0", !active && "invisible")} />
   </button>
 );
 

--- a/components/forms/timelogForm.tsx
+++ b/components/forms/timelogForm.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { FormEvent, useEffect, useRef, useState } from "react";
 import {
   CircleDollarSign,
   Folder,
@@ -32,6 +32,8 @@ interface TimelogProps {
   edit: EditReferenceObj;
   submitHandler: (e: FormEvent, clearForm: Function, selectedData?: SelectedData) => void;
   recent: any;
+  draft?: SelectedData;
+  onDraftChange?: (draft: SelectedData) => void;
 }
 
 type ErrorsObj = {
@@ -48,7 +50,7 @@ const initialDataState = {
   billable: false,
 };
 
-export const TimeLogForm = ({ projects, edit, submitHandler, recent }: TimelogProps) => {
+export const TimeLogForm = ({ projects, edit, submitHandler, recent, draft, onDraftChange }: TimelogProps) => {
   const [onCommentFocus, setOnCommentFocus] = useState<boolean>(false);
   const [selectedData, setSelectedData] = useState<SelectedData>(initialDataState);
   const [projectMilestones, setProjectMilestones] = useState<Milestone[]>([]);
@@ -126,33 +128,35 @@ export const TimeLogForm = ({ projects, edit, submitHandler, recent }: TimelogPr
    */
   const setCommentText = (str: string) => setSelectedData({ ...selectedData, comment: str });
 
+  // Seed local state from a SelectedData snapshot, deriving the project's category/task lists
+  const seedState = (data?: SelectedData | null) => {
+    const found = projects.find((project) => project.id === data?.project?.id);
+    setSelectedData(data && Object.keys(data).length ? data : initialDataState);
+    setProjectMilestones(found?.milestone ?? []);
+    setprojectTasks(found?.task ?? []);
+    setErrors({});
+  };
+
+  // Latest shared draft, read on mount/switch without re-running the effect on every keystroke
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
   useEffect(() => {
     if (edit.isEditing) {
-      const foundProject = projects.find((project) => project.id === edit.obj.project?.id);
-      setSelectedData(edit.obj);
-      setProjectMilestones(() => {
-        const milestone = foundProject?.milestone;
-        return milestone ? milestone : [];
-      });
-      setprojectTasks(() => {
-        const task = foundProject?.task;
-        return task ? task : [];
-      });
+      seedState(edit.obj);
     } else if (recent) {
-      const foundProject = projects.find((project) => project.id === recent.project?.id);
-      setSelectedData(recent);
-      setProjectMilestones(() => {
-        const milestone = foundProject?.milestone;
-        return milestone ? milestone : [];
-      });
-      setprojectTasks(() => {
-        const task = foundProject?.task;
-        return task ? task : [];
-      });
+      seedState(recent);
     } else {
-      handleClearForm();
+      seedState(draftRef.current);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [edit, projects, recent]);
+
+  // Report the live draft up so the other view can pick it up (skip while editing/quick-fill)
+  useEffect(() => {
+    if (!edit.isEditing && !recent) onDraftChange?.(selectedData);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedData, edit.isEditing, recent]);
 
   const renderFormText = () => {
     if (!selectedData.project?.id) return "Select a project first...";

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -281,38 +281,11 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   return (
     <div className="grid w-full grid-cols-12 items-start gap-4">
       <div className="relative col-span-12 md:col-span-8">
-        {/* Mobile: labeled pill toggle above the card */}
-        <div className="mb-2 flex sm:hidden" role="group" aria-label="Logger view">
-          <div className="flex w-full items-center gap-1 rounded-md border bg-background p-0.5">
-            {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
-              <button
-                key={label}
-                type="button"
-                onClick={() => setLogBoardView(board)}
-                aria-pressed={showBoard === board}
-                className={cn(
-                  "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
-                  showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
-                )}
-              >
-                <Icon size={14} />
-                {label}
-                {isNew && (
-                  <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white">
-                    <Sparkles size={9} />
-                    New
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Desktop: floating vertical icon rail in the left gutter (no card space) */}
+        {/* View switcher — mobile: pill bar above card; desktop: floating icon rail in the left gutter */}
         <div
-          className="absolute left-0 top-2 z-10 hidden flex-col items-center gap-1 rounded-md border bg-background p-0.5 shadow-sm sm:flex sm:-translate-x-[calc(100%+0.5rem)]"
           role="group"
           aria-label="Logger view"
+          className="mb-2 flex w-full items-center gap-1 rounded-md border bg-background p-0.5 sm:absolute sm:left-0 sm:top-2 sm:z-10 sm:mb-0 sm:w-auto sm:-translate-x-[calc(100%+0.5rem)] sm:flex-col sm:shadow-sm"
         >
           {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
             <Tooltip key={label}>
@@ -323,20 +296,23 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
                   aria-label={label}
                   aria-pressed={showBoard === board}
                   className={cn(
-                    "relative flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+                    "relative flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors sm:h-8 sm:w-8 sm:flex-none sm:p-0",
                     showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
                   )}
                 >
-                  <Icon size={16} />
+                  <Icon size={14} className="sm:size-4" />
+                  <span className="sm:hidden">{label}</span>
                   {isNew && (
-                    /* magenta "New" flair */
-                    <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-brand-fuchsia text-white">
-                      <Sparkles size={8} />
+                    <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white sm:absolute sm:-right-0.5 sm:-top-0.5 sm:h-3 sm:w-3 sm:justify-center sm:gap-0 sm:p-0">
+                      <Sparkles size={9} className="sm:size-2" />
+                      <span className="sm:hidden">New</span>
                     </span>
                   )}
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="right">{label}</TooltipContent>
+              <TooltipContent side="right" className="hidden sm:block">
+                {label}
+              </TooltipContent>
             </Tooltip>
           ))}
         </div>

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -24,6 +24,15 @@ import NotepadResponse from "./ai/notepad-response";
 import { hoursToDecimal } from "@/lib/helper";
 import { generateId } from "ai";
 
+// Shared config for the Classic/Board view switcher (rendered as mobile pills + desktop rail)
+const VIEW_TOGGLE_ACTIVE = "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50";
+const VIEW_TOGGLE_INACTIVE = "text-muted-foreground hover:bg-muted";
+
+const LOGGER_VIEWS = [
+  { board: false, label: "Classic Timesheet", Icon: Rows3, isNew: false },
+  { board: true, label: "New Timesheet", Icon: LayoutGrid, isNew: true },
+] as const;
+
 export interface RecentEntryProps {
   id: number;
   project?: Project;
@@ -275,34 +284,27 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
         {/* Mobile: labeled pill toggle above the card */}
         <div className="mb-2 flex sm:hidden" role="group" aria-label="Logger view">
           <div className="flex w-full items-center gap-1 rounded-md border bg-background p-0.5">
-            <button
-              type="button"
-              onClick={() => setLogBoardView(false)}
-              aria-pressed={!showBoard}
-              className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
-                !showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
-              )}
-            >
-              <Rows3 size={14} />
-              Classic Timesheet
-            </button>
-            <button
-              type="button"
-              onClick={() => setLogBoardView(true)}
-              aria-pressed={showBoard}
-              className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
-                showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
-              )}
-            >
-              <LayoutGrid size={14} />
-              New Timesheet
-              <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white">
-                <Sparkles size={9} />
-                New
-              </span>
-            </button>
+            {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
+              <button
+                key={label}
+                type="button"
+                onClick={() => setLogBoardView(board)}
+                aria-pressed={showBoard === board}
+                className={cn(
+                  "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
+                  showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
+                )}
+              >
+                <Icon size={14} />
+                {label}
+                {isNew && (
+                  <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white">
+                    <Sparkles size={9} />
+                    New
+                  </span>
+                )}
+              </button>
+            ))}
           </div>
         </div>
 
@@ -312,44 +314,31 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
           role="group"
           aria-label="Logger view"
         >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={() => setLogBoardView(false)}
-                aria-label="Classic Timesheet"
-                aria-pressed={!showBoard}
-                className={cn(
-                  "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-                  !showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
-                )}
-              >
-                <Rows3 size={16} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Classic Timesheet</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={() => setLogBoardView(true)}
-                aria-label="New Timesheet"
-                aria-pressed={showBoard}
-                className={cn(
-                  "relative flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-                  showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
-                )}
-              >
-                <LayoutGrid size={16} />
-                {/* magenta "New" flair */}
-                <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-brand-fuchsia text-white">
-                  <Sparkles size={8} />
-                </span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">New Timesheet</TooltipContent>
-          </Tooltip>
+          {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
+            <Tooltip key={label}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setLogBoardView(board)}
+                  aria-label={label}
+                  aria-pressed={showBoard === board}
+                  className={cn(
+                    "relative flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+                    showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
+                  )}
+                >
+                  <Icon size={16} />
+                  {isNew && (
+                    /* magenta "New" flair */
+                    <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-brand-fuchsia text-white">
+                      <Sparkles size={8} />
+                    </span>
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{label}</TooltipContent>
+            </Tooltip>
+          ))}
         </div>
         <Card className="overflow-hidden shadow-none">
         <div className="flex justify-between gap-2 border-b p-2">

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -18,6 +18,7 @@ import RecentEntries from "./recent-entries";
 import { useGlobalState } from "@/store/useGlobalStore";
 import { LayoutGrid, Rows3, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import AINotepad from "./ai/notepad";
 import NotepadResponse from "./ai/notepad-response";
 import { hoursToDecimal } from "@/lib/helper";
@@ -67,6 +68,8 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   const [edit, setEdit] = useState<EditReferenceObj>({ obj: {}, isEditing: false, id: null });
   const [entries, setEntries] = useState<EntryData>({ data: {}, status: "loading" });
   const [recent, setRecent] = useState(null);
+  // Shared in-progress draft so values persist when switching Classic <-> Board views
+  const [draft, setDraft] = useState<SelectedData>({});
   const [aiInput, setAiInput] = useState<string>("");
   const [aiLoading, setAiLoading] = useState(false);
   const [aiResponses, setAiResponses] = useState<Project[]>([]);
@@ -268,45 +271,85 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
 
   return (
     <div className="grid w-full grid-cols-12 items-start gap-4">
-      <div className="col-span-12 flex flex-col gap-2 md:col-span-8">
-        {/* View switcher — sits outside the card so it doesn't consume card height */}
-        <div className="flex justify-start">
-          <div
-            className="flex shrink-0 items-center overflow-hidden rounded-md border bg-background"
-            role="group"
-            aria-label="Logger view"
-          >
+      <div className="relative col-span-12 md:col-span-8">
+        {/* Mobile: labeled pill toggle above the card */}
+        <div className="mb-2 flex sm:hidden" role="group" aria-label="Logger view">
+          <div className="flex w-full items-center gap-1 rounded-md border bg-background p-0.5">
             <button
               type="button"
               onClick={() => setLogBoardView(false)}
-              title="Classic Timesheet"
               aria-pressed={!showBoard}
               className={cn(
-                "flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs transition-colors",
-                !showBoard ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted",
+                "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
+                !showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
               )}
             >
               <Rows3 size={14} />
-              <span className="hidden sm:inline">Classic Timesheet</span>
+              Classic Timesheet
             </button>
             <button
               type="button"
               onClick={() => setLogBoardView(true)}
-              title="New Timesheet"
               aria-pressed={showBoard}
               className={cn(
-                "flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs transition-colors",
-                showBoard ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted",
+                "flex flex-1 items-center justify-center gap-1.5 rounded-sm px-2 py-1.5 text-xs transition-colors",
+                showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
               )}
             >
               <LayoutGrid size={14} />
-              <span className="hidden sm:inline">New Timesheet</span>
+              New Timesheet
               <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white">
                 <Sparkles size={9} />
                 New
               </span>
             </button>
           </div>
+        </div>
+
+        {/* Desktop: floating vertical icon rail in the left gutter (no card space) */}
+        <div
+          className="absolute left-0 top-2 z-10 hidden flex-col items-center gap-1 rounded-md border bg-background p-0.5 shadow-sm sm:flex sm:-translate-x-[calc(100%+0.5rem)]"
+          role="group"
+          aria-label="Logger view"
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setLogBoardView(false)}
+                aria-label="Classic Timesheet"
+                aria-pressed={!showBoard}
+                className={cn(
+                  "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+                  !showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
+                )}
+              >
+                <Rows3 size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Classic Timesheet</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setLogBoardView(true)}
+                aria-label="New Timesheet"
+                aria-pressed={showBoard}
+                className={cn(
+                  "relative flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+                  showBoard ? "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50" : "text-muted-foreground hover:bg-muted",
+                )}
+              >
+                <LayoutGrid size={16} />
+                {/* magenta "New" flair */}
+                <span className="absolute -right-0.5 -top-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-brand-fuchsia text-white">
+                  <Sparkles size={8} />
+                </span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">New Timesheet</TooltipContent>
+          </Tooltip>
         </div>
         <Card className="overflow-hidden shadow-none">
         <div className="flex justify-between gap-2 border-b p-2">
@@ -319,9 +362,23 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
           />
         </div>
         {showBoard ? (
-          <TimeLogBoard projects={projects} edit={edit} recent={recent} submitHandler={submitTimeEntry} />
+          <TimeLogBoard
+            projects={projects}
+            edit={edit}
+            recent={recent}
+            submitHandler={submitTimeEntry}
+            draft={draft}
+            onDraftChange={setDraft}
+          />
         ) : (
-          <TimeLogForm projects={projects} edit={edit} recent={recent} submitHandler={submitTimeEntry} />
+          <TimeLogForm
+            projects={projects}
+            edit={edit}
+            recent={recent}
+            submitHandler={submitTimeEntry}
+            draft={draft}
+            onDraftChange={setDraft}
+          />
         )}
         {dayTotalTime && (
           <p className="mb-2 flex items-center justify-between px-5 font-medium">

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -13,7 +13,11 @@ import { InlineDatePicker } from "./inline-date-picker";
 import { SelectedData } from "./forms/timelogForm";
 import { Card } from "./ui/card";
 import { TimeLogForm } from "./forms/timelogForm";
+import { TimeLogBoard } from "./forms/timelog-board";
 import RecentEntries from "./recent-entries";
+import { useGlobalState } from "@/store/useGlobalStore";
+import { LayoutGrid, Rows3, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
 import AINotepad from "./ai/notepad";
 import NotepadResponse from "./ai/notepad-response";
 import { hoursToDecimal } from "@/lib/helper";
@@ -66,11 +70,19 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   const [aiInput, setAiInput] = useState<string>("");
   const [aiLoading, setAiLoading] = useState(false);
   const [aiResponses, setAiResponses] = useState<Project[]>([]);
+  const logBoardView = useGlobalState((state) => state.logBoardView);
+  const setLogBoardView = useGlobalState((state) => state.setLogBoardView);
 
   // This sets the AI input from the local storage
   useEffect(() => {
     setAiInput(localStorage?.getItem("notebook-input") || "");
   }, []);
+
+  // Guard against hydration mismatch: the view preference is rehydrated from
+  // localStorage only on the client, so render the default (classic) until mounted.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const showBoard = mounted && logBoardView;
 
   const editEntryHandler = (obj: SelectedData, id: number) => {
     setRecent(null);
@@ -256,7 +268,47 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
 
   return (
     <div className="grid w-full grid-cols-12 items-start gap-4">
-      <Card className="col-span-12 overflow-hidden shadow-none md:col-span-8">
+      <div className="col-span-12 flex flex-col gap-2 md:col-span-8">
+        {/* View switcher — sits outside the card so it doesn't consume card height */}
+        <div className="flex justify-start">
+          <div
+            className="flex shrink-0 items-center overflow-hidden rounded-md border bg-background"
+            role="group"
+            aria-label="Logger view"
+          >
+            <button
+              type="button"
+              onClick={() => setLogBoardView(false)}
+              title="Classic Timesheet"
+              aria-pressed={!showBoard}
+              className={cn(
+                "flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs transition-colors",
+                !showBoard ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              <Rows3 size={14} />
+              <span className="hidden sm:inline">Classic Timesheet</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setLogBoardView(true)}
+              title="New Timesheet"
+              aria-pressed={showBoard}
+              className={cn(
+                "flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs transition-colors",
+                showBoard ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              <LayoutGrid size={14} />
+              <span className="hidden sm:inline">New Timesheet</span>
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-brand-fuchsia px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white">
+                <Sparkles size={9} />
+                New
+              </span>
+            </button>
+          </div>
+        </div>
+        <Card className="overflow-hidden shadow-none">
         <div className="flex justify-between gap-2 border-b p-2">
           <InlineDatePicker
             date={date}
@@ -266,7 +318,11 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
             dayTotalTime={dayTotalTime}
           />
         </div>
-        <TimeLogForm projects={projects} edit={edit} recent={recent} submitHandler={submitTimeEntry} />
+        {showBoard ? (
+          <TimeLogBoard projects={projects} edit={edit} recent={recent} submitHandler={submitTimeEntry} />
+        ) : (
+          <TimeLogForm projects={projects} edit={edit} recent={recent} submitHandler={submitTimeEntry} />
+        )}
         {dayTotalTime && (
           <p className="mb-2 flex items-center justify-between px-5 font-medium">
             Total time logged for the day
@@ -280,7 +336,8 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
           editEntryHandler={editEntryHandler}
           edit={edit}
         />
-      </Card>
+        </Card>
+      </div>
       <div className="col-span-12 flex flex-col gap-4 md:col-span-4">
         <RecentEntries recentTimeEntries={recentTimeEntries} handleRecentClick={handleRecentClick} />
         <AINotepad

--- a/store/useGlobalStore.ts
+++ b/store/useGlobalStore.ts
@@ -4,17 +4,21 @@ import { persist } from "zustand/middleware";
 // Define the interface of the Global state
 interface GlobalState {
   showArchived: boolean; // Show archived items
+  logBoardView: boolean; // Use the new click-to-select board for logging time (false = classic form)
 }
 
 // Define the interface of the actions that can be performed
 interface GlobalStateActions {
   toggleArchived: () => void;
+  setLogBoardView: (value: boolean) => void;
+  toggleLogBoardView: () => void;
   reset: () => void;
 }
 
 // Initialize a default state
 const INITIAL_STATE: GlobalState = {
   showArchived: false,
+  logBoardView: false,
 };
 
 // Create the store with Zustand, combining the status interface and actions
@@ -27,6 +31,12 @@ const createGlobalState = (key: string) => {
           set((state) => ({
             showArchived: !state.showArchived,
           }));
+        },
+        setLogBoardView(value: boolean) {
+          set(() => ({ logBoardView: value }));
+        },
+        toggleLogBoardView() {
+          set((state) => ({ logBoardView: !state.logBoardView }));
         },
         reset() {
           set(INITIAL_STATE);


### PR DESCRIPTION
## Summary

Logger Entry UI/UX refresh. Adds a new **click-to-select "New Timesheet" board** as an alternative to the classic dropdown form, to cut clicks when logging time. A view switcher lets users toggle between the two; the choice is remembered.

## Screenshot
<img width="766" height="633" alt="image" src="https://github.com/user-attachments/assets/4824300b-522e-4525-a30c-7eaeda6998a7" />


## What's new

- **`TimeLogBoard`** (`components/forms/timelog-board.tsx`) — Kanban-ish layout:
  - 3 cascading columns **Project → Category → Task**, grouped by client, direct click-to-select (re-click Category/Task to deselect).
  - **Per-column in-header search** — click the title (I-beam cursor) or 🔍 to expand an inline input; ✕ / `Esc` to close.
  - Compose bar: comment + quick chips (`+15m/+30m/+1h`) + `−/+` stepper (rounds to nearest 30 min) + billable toggle + submit.
- **View switcher** (`Classic Timesheet` / `New Timesheet`) above the card, with a magenta ✨ New tag. Preference persisted via the zustand global store (localStorage). **Defaults to Classic.**

## Friction reducers
- Comment box always editable; timer usable without a project selected (submit still requires a project).

## Implementation notes
- Reuses the existing `SelectedData` shape and `submitHandler`, so the POST/PUT payload to `/api/team/time-entry` is **identical** to the classic form.
- Classic `TimeLogForm` left fully intact.
- `components/time-add.tsx` (mobile drawer) not touched — could mirror the board in a follow-up.

## Verification
- `tsc --noEmit` clean, `eslint` clean (pre-existing effect warnings only).
- Functional verification pending (reviewer / author to test in-app).