### PR TITLE
chore: Update Packages & Polish New Timesheet

### DIFF
--- a/app/[team]/page.tsx
+++ b/app/[team]/page.tsx
@@ -8,6 +8,7 @@ import { pageProps } from "@/types";
 import { getTimeInHours } from "@/lib/helper";
 
 import { TimeEntry } from "@/components/time-entry";
+import { DashboardShell } from "@/components/dashboard-shell";
 import CategoryDataBar from "@/components/charts/category-bar";
 import WeekHeatmap from "@/components/charts/week-heatmap";
 import { endOfWeek, format, parse, startOfWeek } from "date-fns";
@@ -31,27 +32,34 @@ export default async function Dashboard(props: pageProps) {
   const maxHourPerDay = 7.5;
   const weekStart = startOfWeek(date, { weekStartsOn: 0 });
   const weekEnd = endOfWeek(date, { weekStartsOn: 0 });
+  const weekHours = {
+    title: "Hours logged",
+    subtitle: `${format(weekStart, "MMM d")} - ${format(weekEnd, "MMM d")}`,
+    markerValue: getTimeInHours(loggedTime),
+    maxValue: maxHourPerDay * 5,
+  };
 
   return (
-    <div className="col-span-12 mb-6 grid w-full grid-cols-12 items-start gap-4">
-      <main className="col-span-12 flex flex-col gap-4 lg:col-span-9">
-        <TimeEntry
-          team={team}
-          projects={projects ? projects : []}
-          recentTimeEntries={recentTimeEntries}
-          initialDate={date}
-        />
-      </main>
-      <aside className="hidden space-y-4 lg:col-span-3 lg:block">
-        <CategoryDataBar
-          title="Hours logged"
-          subtitle={`${format(weekStart, "MMM d")} - ${format(weekEnd, "MMM d")}`}
-          markerValue={getTimeInHours(loggedTime)}
-          maxValue={maxHourPerDay * 5}
-          type="hours"
-        />
-        <WeekHeatmap sevenWeekTimeEntries={sevenWeekTimeEntries} selectedDate={date} />
-      </aside>
-    </div>
+    <DashboardShell
+      aside={
+        <>
+          <CategoryDataBar
+            title={weekHours.title}
+            subtitle={weekHours.subtitle}
+            markerValue={weekHours.markerValue}
+            maxValue={weekHours.maxValue}
+            type="hours"
+          />
+          <WeekHeatmap sevenWeekTimeEntries={sevenWeekTimeEntries} selectedDate={date} />
+        </>
+      }
+    >
+      <TimeEntry
+        team={team}
+        projects={projects ? projects : []}
+        recentTimeEntries={recentTimeEntries}
+        initialDate={date}
+      />
+    </DashboardShell>
   );
 }

--- a/components/ai/notepad.tsx
+++ b/components/ai/notepad.tsx
@@ -9,12 +9,19 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
 
 type AINotepadProps = {
   notebookSubmitHandler: (input: string) => void;
   aiLoading: boolean;
   aiInput: string;
   setAiInput: (input: string) => void;
+  /** card = classic accordion card; inline = flat strip for board form */
+  variant?: "card" | "inline";
+  /** When false, accordion starts collapsed (board aside). Default true for classic. */
+  defaultOpen?: boolean;
+  /** Shorter textarea for constrained sidebars */
+  compact?: boolean;
 };
 
 declare global {
@@ -23,7 +30,16 @@ declare global {
     webkitSpeechRecognition: any;
   }
 }
-export default function AINotepad({ notebookSubmitHandler, aiInput, setAiInput, aiLoading }: AINotepadProps) {
+
+export default function AINotepad({
+  notebookSubmitHandler,
+  aiInput,
+  setAiInput,
+  aiLoading,
+  variant = "card",
+  defaultOpen = true,
+  compact = false,
+}: AINotepadProps) {
   const [isCopied, setIsCopied] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [isRecordingSupported, setIsRecordingSupported] = useState(true);
@@ -99,102 +115,121 @@ export default function AINotepad({ notebookSubmitHandler, aiInput, setAiInput, 
     if (voiceError === "error") setIsRecordingSupported(false);
   }, [voiceError]);
 
+  const form = (
+    <form
+      onSubmit={(e) => {
+        if (aiLoading || !aiInput.trim()) return;
+        e.preventDefault();
+        notebookSubmitHandler(aiInput);
+      }}
+      className={cn("flex flex-col", variant === "inline" || compact ? "gap-2" : "gap-4")}
+    >
+      <Textarea
+        value={aiInput}
+        onChange={(e) => {
+          setAiInput(e.target.value);
+          localStorage.setItem("notebook-input", e.target.value);
+        }}
+        onKeyDown={(e) => {
+          const ctrlKey = e.ctrlKey || e.metaKey;
+          if (ctrlKey && e.key === "Enter" && aiInput.trim()) {
+            notebookSubmitHandler(aiInput);
+          }
+        }}
+        rows={variant === "inline" || compact ? 3 : 8}
+        placeholder="Fixed and deployed on LOG-8 - 2h"
+        className={cn(
+          "resize-none",
+          (variant === "inline" || compact) && "min-h-[4.5rem] text-sm",
+          variant === "inline" && "bg-transparent shadow-none",
+        )}
+      />
+      <div className="relative flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          {isRecordingSupported && (
+            <Button
+              type="button"
+              onClick={() => setIsRecording((prevState) => !prevState)}
+              size="icon"
+              variant="outline"
+              className={cn("relative", (variant === "inline" || compact) && "h-8 w-8")}
+              title="Start voice typing"
+            >
+              {isRecording && (
+                <>
+                  <span className="bg-muted-foreground absolute -top-1 -right-1 h-2.5 w-2.5 animate-ping rounded-full" />
+                  <span className="bg-muted-foreground absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full" />
+                </>
+              )}
+              {isRecording ? <MicOff size={16} /> : <Mic size={16} />}
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            title="Copy to clipboard"
+            disabled={!aiInput.trim()}
+            onClick={copyToClipboard}
+            className={cn((variant === "inline" || compact) && "h-8 w-8")}
+          >
+            {isCopied ? <Check size={16} /> : <Clipboard size={16} />}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            disabled={!aiInput.trim()}
+            title="Clear"
+            onClick={() => {
+              setAiInput("");
+              localStorage.removeItem("notebook-input");
+            }}
+            className={cn((variant === "inline" || compact) && "h-8 w-8")}
+          >
+            <ListRestart size={16} />
+          </Button>
+        </div>
+        <Button
+          size="sm"
+          type="submit"
+          className="flex items-center gap-2"
+          disabled={aiLoading || !aiInput.trim()}
+          title="Submit - (Ctrl/Cmd + Enter)"
+        >
+          Submit
+          {aiLoading ? <Loader2 size={16} className="animate-spin" /> : <span className="dark:grayscale dark:invert">✨</span>}
+        </Button>
+      </div>
+    </form>
+  );
+
+  if (variant === "inline") {
+    return (
+      <div className="border-t px-3 py-2 sm:px-4">
+        <p className="text-muted-foreground pb-1.5 text-[10px] font-semibold tracking-wide uppercase">Notebook</p>
+        {form}
+      </div>
+    );
+  }
+
   return (
     <Card className="overflow-hidden p-0 shadow-none">
-      <Accordion type="single" className="w-full" collapsible defaultValue="item-1">
+      <Accordion
+        type="single"
+        className="w-full"
+        collapsible
+        defaultValue={defaultOpen ? "item-1" : undefined}
+      >
         <AccordionItem value="item-1" className="border-b-0">
-          <AccordionTrigger className="p-4 hover:no-underline" tabIndex={-1}>
+          <AccordionTrigger className={cn("hover:no-underline", compact ? "px-3 py-2.5" : "p-4")} tabIndex={-1}>
             <CardHeader className="flex flex-row items-center justify-between p-0">
-              <p className="text-sm font-medium text-muted-foreground">Notebook</p>
+              <p className="text-muted-foreground text-sm font-medium">Notebook</p>
             </CardHeader>
           </AccordionTrigger>
-          <AccordionContent>
-            <CardContent className="px-4 py-1">
-              <form
-                onSubmit={(e) => {
-                  if (aiLoading || !aiInput.trim()) return;
-                  e.preventDefault();
-                  notebookSubmitHandler(aiInput);
-                }}
-                className="flex flex-col gap-4"
-              >
-                <Textarea
-                  value={aiInput}
-                  onChange={(e) => {
-                    setAiInput(e.target.value);
-                    localStorage.setItem("notebook-input", e.target.value);
-                  }}
-                  onKeyDown={(e) => {
-                    const ctrlKey = e.ctrlKey || e.metaKey;
-                    if (ctrlKey && e.key === "Enter" && aiInput.trim()) {
-                      notebookSubmitHandler(aiInput);
-                    }
-                  }}
-                  rows={8}
-                  placeholder="Fixed and deployed on LOG-8 - 2h"
-                  className="resize-none"
-                />
-                <div className="relative flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    {isRecordingSupported && (
-                      <Button
-                        type="button"
-                        onClick={() => setIsRecording((prevState) => !prevState)}
-                        size="icon"
-                        variant="outline"
-                        className="relative"
-                        title="Start voice typing"
-                      >
-                        {isRecording && (
-                          <>
-                            <span className="absolute -right-1 -top-1 h-2.5 w-2.5 animate-ping rounded-full bg-muted-foreground" />
-                            <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-muted-foreground" />
-                          </>
-                        )}
-                        {isRecording ? <MicOff size={16} /> : <Mic size={16} />}
-                      </Button>
-                    )}
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      title="Copy to clipboard"
-                      disabled={!aiInput.trim()}
-                      onClick={copyToClipboard}
-                    >
-                      {isCopied ? <Check size={16} /> : <Clipboard size={16} />}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      disabled={!aiInput.trim()}
-                      title="Clear"
-                      onClick={() => {
-                        setAiInput("");
-                        localStorage.removeItem("notebook-input");
-                      }}
-                    >
-                      <ListRestart size={16} />
-                    </Button>
-                  </div>
-                  <Button
-                    size="sm"
-                    type="submit"
-                    className="flex items-center gap-2"
-                    disabled={aiLoading || !aiInput.trim()}
-                    title="Submit - (Ctrl/Cmd + Enter)"
-                  >
-                    Submit
-                    {aiLoading ? (
-                      <Loader2 size={16} className="animate-spin" />
-                    ) : (
-                      <span className="dark:grayscale dark:invert">✨</span>
-                    )}
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
+          <AccordionContent className={cn(compact && "!h-auto pb-0")}>
+            {/* pt so textarea border isn't clipped by accordion overflow-hidden */}
+            <CardContent className={cn(compact ? "px-3 pt-1.5 pb-3" : "px-4 pt-1 pb-1")}>{form}</CardContent>
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/components/charts/category-bar.tsx
+++ b/components/charts/category-bar.tsx
@@ -51,7 +51,7 @@ export default function CategoryDataBar({ markerValue, maxValue, title, subtitle
   }, [targetPercent]);
 
   return (
-    <section className="border-border bg-card rounded-lg border p-4">
+    <section className="border-border bg-card h-full rounded-lg border p-4">
       <div className="mb-5 flex items-start justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-sm font-medium">{title}</h2>

--- a/components/charts/week-heatmap.tsx
+++ b/components/charts/week-heatmap.tsx
@@ -65,7 +65,7 @@ export default function WeekHeatmap({ sevenWeekTimeEntries, selectedDate }: Week
   }
 
   return (
-    <section className="border-border bg-card rounded-lg border p-4">
+    <section className="border-border bg-card h-full rounded-lg border p-4">
       <div className="mb-3 flex items-center justify-between gap-2">
         <div>
           <h2 className="text-sm font-medium">Heatmap</h2>

--- a/components/custom/tooltip.tsx
+++ b/components/custom/tooltip.tsx
@@ -13,7 +13,7 @@ export function CustomTooltip({ trigger, content, sideOffset, contentClassName }
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>{trigger}</TooltipTrigger>
-        <TooltipContent className={cn("max-w-[300px]", contentClassName)} sideOffset={sideOffset}>
+        <TooltipContent className={cn("max-w-75", contentClassName)} sideOffset={sideOffset}>
           {typeof content === "string" ? <p>{content}</p> : content}
         </TooltipContent>
       </Tooltip>

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -14,11 +14,11 @@ interface DashboardShellProps {
  */
 export function DashboardShell({ children, aside }: DashboardShellProps) {
   return (
-    <div className="col-span-12 mb-6 grid w-full grid-cols-12 items-start gap-4">
-      <main className="col-span-12 flex flex-col gap-4 lg:col-span-9">{children}</main>
-      <aside className="col-span-12 space-y-4 lg:sticky lg:top-[4.5rem] lg:col-span-3 lg:max-h-[calc(100vh-7.5rem)] lg:overflow-y-auto">
+    <div className="col-span-12 mb-6 grid w-full grid-cols-12 items-start gap-2.5">
+      <main className="col-span-12 flex flex-col gap-2.5 lg:col-span-9">{children}</main>
+      <aside className="col-span-12 space-y-2.5 lg:sticky lg:top-[4.5rem] lg:col-span-3 lg:max-h-[calc(100vh-7.5rem)] lg:overflow-y-auto">
         {aside}
-        <div id="board-notebook-slot" className="flex flex-col gap-4 empty:hidden" />
+        <div id="board-notebook-slot" className="flex flex-col gap-2.5 empty:hidden" />
       </aside>
     </div>
   );

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface DashboardShellProps {
+  children: ReactNode;
+  aside: ReactNode;
+}
+
+/**
+ * Team home grid: primary logger (9) + analytics aside (3).
+ * Aside grows with content up to the viewport; scrolls only if needed on large screens.
+ * `#board-notebook-slot` receives the board notebook under heatmap.
+ */
+export function DashboardShell({ children, aside }: DashboardShellProps) {
+  return (
+    <div className="col-span-12 mb-6 grid w-full grid-cols-12 items-start gap-4">
+      <main className="col-span-12 flex flex-col gap-4 lg:col-span-9">{children}</main>
+      <aside className="col-span-12 space-y-4 lg:sticky lg:top-[4.5rem] lg:col-span-3 lg:max-h-[calc(100vh-7.5rem)] lg:overflow-y-auto">
+        {aside}
+        <div id="board-notebook-slot" className="flex flex-col gap-4 empty:hidden" />
+      </aside>
+    </div>
+  );
+}

--- a/components/date-picker.tsx
+++ b/components/date-picker.tsx
@@ -15,6 +15,7 @@ import { GetSetDateProps } from "@/types";
 interface DatePickerProps extends GetSetDateProps {
   children?: React.ReactNode;
   align?: "center" | "start" | "end";
+  className?: string;
 }
 
 export const DatePicker = ({ date, setDate }: GetSetDateProps) => {
@@ -23,7 +24,7 @@ export const DatePicker = ({ date, setDate }: GetSetDateProps) => {
       <PopoverTrigger asChild>
         <Button
           variant="outline"
-          className={cn("w-[280px] justify-start text-left font-normal", !date && "text-muted-foreground")}
+          className={cn("w-70 justify-start text-left font-normal", !date && "text-muted-foreground")}
         >
           <CalendarIcon className="mr-2 h-4 w-4" />
           {date ? format(date, "PPP") : <span>Pick a date</span>}
@@ -36,7 +37,7 @@ export const DatePicker = ({ date, setDate }: GetSetDateProps) => {
   );
 };
 
-export const ClassicDatePicker = ({ date, setDate, children, align = "center" }: DatePickerProps) => {
+export const ClassicDatePicker = ({ date, setDate, children, align = "center", className }: DatePickerProps) => {
   const [open, setOpen] = useState(false);
   const todaysDate = new Date();
 
@@ -46,7 +47,7 @@ export const ClassicDatePicker = ({ date, setDate, children, align = "center" }:
         <Button
           variant="outline"
           size="sm"
-          className={cn("flex w-full justify-center gap-1.5", children ? "w-[170px]" : "")}
+          className={cn("flex w-full justify-center gap-1.5", children ? "w-42.5" : "", className)}
         >
           <CalendarIcon className="shrink-0" size={16} />
           {date && !children ? format(date, "PPP") : !children && <span className="text-sm">Pick a date</span>}
@@ -151,7 +152,7 @@ export function CalendarDateRangePicker({
               <div className="grid gap-1.5 leading-none">
                 <label
                   htmlFor="terms1"
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   Set as Ongoing
                 </label>

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -322,19 +322,22 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
           <ScrollArea className="max-h-[240px] sm:h-[240px]">
             <div className="p-1.5">
               {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
-              {groupedProjects.map((group) => (
-                <div key={group.clientId} className="mb-1">
-                  <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {group.clientName}
-                  </p>
-                  {group.projects.map((project) => (
-                    <BoardItem
-                      key={project.id}
-                      label={project.name}
-                      active={selectedData?.project?.id === project.id}
-                      onClick={() => projectCallback(project)}
-                    />
-                  ))}
+              {groupedProjects.map((group, index) => (
+                <div key={group.clientId}>
+                  <div className="mb-1">
+                    <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      {group.clientName}
+                    </p>
+                    {group.projects.map((project) => (
+                      <BoardItem
+                        key={project.id}
+                        label={project.name}
+                        active={selectedData?.project?.id === project.id}
+                        onClick={() => projectCallback(project)}
+                      />
+                    ))}
+                  </div>
+                  {index !== groupedProjects.length - 1 && <div className="bg-border/40 my-1 h-px" />}
                 </div>
               ))}
             </div>

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -18,7 +18,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Project, Milestone } from "@/types";
 import { EditReferenceObj } from "../time-entry";
 import { cn } from "@/lib/utils";
@@ -303,8 +302,8 @@ export const TimeLogBoard = ({
   const showCategories = projectMilestones.length > 0;
   const showTasks = projectTasks.length > 0;
   const boardColumnCount = 1 + Number(showCategories) + Number(showTasks);
-  // Fixed list height so columns don't jump when category/task panes appear
-  const columnListClass = "h-[240px]";
+  // Cap list height so long lists scroll; short lists shrink to content (no empty whitespace).
+  const columnListClass = "max-h-[280px] overflow-y-auto";
 
   return (
     <div>
@@ -328,7 +327,7 @@ export const TimeLogBoard = ({
             open={projectSearchOpen}
             setOpen={setProjectSearchOpen}
           />
-          <ScrollArea className={columnListClass}>
+          <div className={columnListClass}>
             <div className="p-1.5">
               {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
               {groupedProjects.map((group, index) => (
@@ -350,7 +349,7 @@ export const TimeLogBoard = ({
                 </div>
               ))}
             </div>
-          </ScrollArea>
+          </div>
         </div>
 
         {/* Column 2: Categories (milestones) — only when the project has any */}
@@ -367,7 +366,7 @@ export const TimeLogBoard = ({
               setOpen={setCategorySearchOpen}
               disabled={!isProjectSelected}
             />
-            <ScrollArea className={columnListClass}>
+            <div className={columnListClass}>
               <div className="p-1.5">
                 {filteredMilestones.length === 0 ? (
                   <EmptyState text="No matches" />
@@ -382,7 +381,7 @@ export const TimeLogBoard = ({
                   ))
                 )}
               </div>
-            </ScrollArea>
+            </div>
           </div>
         )}
 
@@ -400,7 +399,7 @@ export const TimeLogBoard = ({
               setOpen={setTaskSearchOpen}
               disabled={!isProjectSelected}
             />
-            <ScrollArea className={columnListClass}>
+            <div className={columnListClass}>
               <div className="p-1.5">
                 {filteredTasks.length === 0 ? (
                   <EmptyState text="No matches" />
@@ -415,7 +414,7 @@ export const TimeLogBoard = ({
                   ))
                 )}
               </div>
-            </ScrollArea>
+            </div>
           </div>
         )}
       </div>

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -69,7 +69,14 @@ const TIME_CHIPS = [
   { id: 3, title: "+1h", incrementBy: 1 },
 ];
 
-export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onDraftChange }: TimelogBoardProps) => {
+export const TimeLogBoard = ({
+  projects,
+  edit,
+  submitHandler,
+  recent,
+  draft,
+  onDraftChange,
+}: TimelogBoardProps) => {
   const [selectedData, setSelectedData] = useState<SelectedData>(initialDataState);
   const [projectMilestones, setProjectMilestones] = useState<Milestone[]>([]);
   const [projectTasks, setprojectTasks] = useState<Milestone[]>([]);
@@ -296,6 +303,8 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
   const showCategories = projectMilestones.length > 0;
   const showTasks = projectTasks.length > 0;
   const boardColumnCount = 1 + Number(showCategories) + Number(showTasks);
+  // Fixed list height so columns don't jump when category/task panes appear
+  const columnListClass = "h-[240px]";
 
   return (
     <div>
@@ -319,13 +328,13 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
             open={projectSearchOpen}
             setOpen={setProjectSearchOpen}
           />
-          <ScrollArea className="max-h-[240px] sm:h-[240px]">
+          <ScrollArea className={columnListClass}>
             <div className="p-1.5">
               {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
               {groupedProjects.map((group, index) => (
                 <div key={group.clientId}>
                   <div className="mb-1">
-                    <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    <p className="text-muted-foreground px-2 py-1 text-[10px] font-semibold tracking-wide uppercase">
                       {group.clientName}
                     </p>
                     {group.projects.map((project) => (
@@ -358,7 +367,7 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
               setOpen={setCategorySearchOpen}
               disabled={!isProjectSelected}
             />
-            <ScrollArea className="max-h-[240px] sm:h-[240px]">
+            <ScrollArea className={columnListClass}>
               <div className="p-1.5">
                 {filteredMilestones.length === 0 ? (
                   <EmptyState text="No matches" />
@@ -391,7 +400,7 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
               setOpen={setTaskSearchOpen}
               disabled={!isProjectSelected}
             />
-            <ScrollArea className="max-h-[240px] sm:h-[240px]">
+            <ScrollArea className={columnListClass}>
               <div className="p-1.5">
                 {filteredTasks.length === 0 ? (
                   <EmptyState text="No matches" />
@@ -420,11 +429,11 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
       >
         <div className="flex flex-col gap-2 p-3 sm:px-4">
           {/* Row 1: comment input */}
-          <div className="flex min-h-[52px] items-start rounded-md border bg-background px-2 py-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary">
-            <MessageSquare className="mt-1 shrink-0 text-muted-foreground" size={16} />
+          <div className="border-border bg-background focus-within:border-primary focus-within:ring-primary flex min-h-[52px] items-start rounded-md border px-2 py-2 focus-within:ring-1">
+            <MessageSquare className="text-muted-foreground mt-1 shrink-0" size={16} />
             <textarea
               rows={2}
-              className="min-h-[36px] w-full resize-y border-0 bg-transparent px-2 py-0.5 text-sm focus:outline-0 focus:ring-0"
+              className="min-h-[36px] w-full resize-y border-0 bg-transparent px-2 py-0.5 text-sm focus:ring-0 focus:outline-0"
               placeholder="Add a comment..."
               value={selectedData?.comment ?? ""}
               onChange={(e) => setCommentText(e.target.value)}

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -542,7 +542,7 @@ export const TimeLogBoard = ({
                 )}
 
                 <Button size="sm" type="submit" disabled={!formValidator()} className="shrink-0">
-                  {edit.isEditing ? "Update" : "Submit"}
+                  {edit.isEditing ? "Save" : "Add"}
                 </Button>
               </div>
             </div>

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -298,146 +298,146 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
   const boardColumnCount = 1 + Number(showCategories) + Number(showTasks);
 
   return (
-    <div className="p-2">
-      <div className="overflow-hidden rounded-xl border">
-        {/* Cascading columns: Project -> Category/Task when the selected project has them */}
-        <div
-          className={cn(
-            "grid grid-cols-1 divide-y sm:divide-x sm:divide-y-0",
-            boardColumnCount === 1 && "sm:grid-cols-1",
-            boardColumnCount === 2 && "sm:grid-cols-2",
-            boardColumnCount === 3 && "sm:grid-cols-3",
-          )}
-        >
-          {/* Column 1: Projects (grouped by client) */}
+    <div>
+      {/* Cascading columns: Project -> Category/Task when the selected project has them.
+          No top border here — the parent card header already provides one. */}
+      <div
+        className={cn(
+          "grid grid-cols-1 divide-y sm:divide-x sm:divide-y-0",
+          boardColumnCount === 1 && "sm:grid-cols-1",
+          boardColumnCount === 2 && "sm:grid-cols-2",
+          boardColumnCount === 3 && "sm:grid-cols-3",
+        )}
+      >
+        {/* Column 1: Projects (grouped by client) */}
+        <div className="flex min-w-0 flex-col">
+          <SearchableHeader
+            icon={<Folder size={14} className="shrink-0" />}
+            label="Project"
+            query={projectQuery}
+            setQuery={setProjectQuery}
+            open={projectSearchOpen}
+            setOpen={setProjectSearchOpen}
+          />
+          <ScrollArea className="max-h-[240px] sm:h-[240px]">
+            <div className="p-1.5">
+              {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
+              {groupedProjects.map((group) => (
+                <div key={group.clientId} className="mb-1">
+                  <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {group.clientName}
+                  </p>
+                  {group.projects.map((project) => (
+                    <BoardItem
+                      key={project.id}
+                      label={project.name}
+                      active={selectedData?.project?.id === project.id}
+                      onClick={() => projectCallback(project)}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Column 2: Categories (milestones) — only when the project has any */}
+        {showCategories && (
           <div className="flex min-w-0 flex-col">
             <SearchableHeader
-              icon={<Folder size={14} className="shrink-0" />}
-              label="Project"
-              query={projectQuery}
-              setQuery={setProjectQuery}
-              open={projectSearchOpen}
-              setOpen={setProjectSearchOpen}
+              icon={<CategoryIcon size={14} className="shrink-0" />}
+              label="Category"
+              required={categoryRequired}
+              missingRequired={categoryMissing}
+              query={categoryQuery}
+              setQuery={setCategoryQuery}
+              open={categorySearchOpen}
+              setOpen={setCategorySearchOpen}
+              disabled={!isProjectSelected}
             />
             <ScrollArea className="max-h-[240px] sm:h-[240px]">
               <div className="p-1.5">
-                {groupedProjects.length === 0 && <EmptyState text="No projects found" />}
-                {groupedProjects.map((group) => (
-                  <div key={group.clientId} className="mb-1">
-                    <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                      {group.clientName}
-                    </p>
-                    {group.projects.map((project) => (
-                      <BoardItem
-                        key={project.id}
-                        label={project.name}
-                        active={selectedData?.project?.id === project.id}
-                        onClick={() => projectCallback(project)}
-                      />
-                    ))}
-                  </div>
-                ))}
+                {filteredMilestones.length === 0 ? (
+                  <EmptyState text="No matches" />
+                ) : (
+                  filteredMilestones.map((milestone) => (
+                    <BoardItem
+                      key={milestone.id}
+                      label={milestone.name}
+                      active={selectedData?.milestone?.id === milestone.id}
+                      onClick={() => milestoneCallback(milestone)}
+                    />
+                  ))
+                )}
               </div>
             </ScrollArea>
           </div>
+        )}
 
-          {/* Column 2: Categories (milestones) — only when the project has any */}
-          {showCategories && (
-            <div className="flex min-w-0 flex-col">
-              <SearchableHeader
-                icon={<CategoryIcon size={14} className="shrink-0" />}
-                label="Category"
-                required={categoryRequired}
-                missingRequired={categoryMissing}
-                query={categoryQuery}
-                setQuery={setCategoryQuery}
-                open={categorySearchOpen}
-                setOpen={setCategorySearchOpen}
-                disabled={!isProjectSelected}
-              />
-              <ScrollArea className="max-h-[240px] sm:h-[240px]">
-                <div className="p-1.5">
-                  {filteredMilestones.length === 0 ? (
-                    <EmptyState text="No matches" />
-                  ) : (
-                    filteredMilestones.map((milestone) => (
-                      <BoardItem
-                        key={milestone.id}
-                        label={milestone.name}
-                        active={selectedData?.milestone?.id === milestone.id}
-                        onClick={() => milestoneCallback(milestone)}
-                      />
-                    ))
-                  )}
-                </div>
-              </ScrollArea>
-            </div>
-          )}
+        {/* Column 3: Tasks — only when the project has any */}
+        {showTasks && (
+          <div className="flex min-w-0 flex-col">
+            <SearchableHeader
+              icon={<List size={14} className="shrink-0" />}
+              label="Task"
+              required={taskRequired}
+              missingRequired={taskMissing}
+              query={taskQuery}
+              setQuery={setTaskQuery}
+              open={taskSearchOpen}
+              setOpen={setTaskSearchOpen}
+              disabled={!isProjectSelected}
+            />
+            <ScrollArea className="max-h-[240px] sm:h-[240px]">
+              <div className="p-1.5">
+                {filteredTasks.length === 0 ? (
+                  <EmptyState text="No matches" />
+                ) : (
+                  filteredTasks.map((task) => (
+                    <BoardItem
+                      key={task.id}
+                      label={task.name}
+                      active={selectedData?.task?.id === task.id}
+                      onClick={() => taskCallback(task)}
+                    />
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        )}
+      </div>
 
-          {/* Column 3: Tasks — only when the project has any */}
-          {showTasks && (
-            <div className="flex min-w-0 flex-col">
-              <SearchableHeader
-                icon={<List size={14} className="shrink-0" />}
-                label="Task"
-                required={taskRequired}
-                missingRequired={taskMissing}
-                query={taskQuery}
-                setQuery={setTaskQuery}
-                open={taskSearchOpen}
-                setOpen={setTaskSearchOpen}
-                disabled={!isProjectSelected}
-              />
-              <ScrollArea className="max-h-[240px] sm:h-[240px]">
-                <div className="p-1.5">
-                  {filteredTasks.length === 0 ? (
-                    <EmptyState text="No matches" />
-                  ) : (
-                    filteredTasks.map((task) => (
-                      <BoardItem
-                        key={task.id}
-                        label={task.name}
-                        active={selectedData?.task?.id === task.id}
-                        onClick={() => taskCallback(task)}
-                      />
-                    ))
-                  )}
-                </div>
-              </ScrollArea>
-            </div>
-          )}
-        </div>
-
-        {/* Compose bar: comment + time + billable + submit */}
-        <form
-          onSubmit={(e) => submitHandler(e, handleClearForm, selectedData)}
-          onKeyDown={(e) => e.key === "Enter" && formValidator() && submitHandler(e, handleClearForm, selectedData)}
-          autoComplete="off"
-          className="border-t bg-muted/30"
-        >
-          <div className="flex flex-col gap-2 p-2">
-            {/* Row 1: comment box — always editable to reduce friction */}
-            <div className="flex min-h-[52px] items-start rounded-md border bg-background px-2 py-2">
-              <MessageSquare className="mt-1 shrink-0 text-muted-foreground" size={16} />
-              <textarea
-                rows={2}
-                className="min-h-[36px] w-full resize-y border-0 bg-transparent px-2 py-0.5 text-sm focus:outline-0 focus:ring-0"
-                placeholder="Add a comment..."
-                value={selectedData?.comment ?? ""}
-                onChange={(e) => setCommentText(e.target.value)}
-                onKeyDown={(e) => {
-                  // Enter submits; Shift+Enter adds a newline.
-                  // Stop propagation so the form-level Enter handler doesn't also fire.
-                  if (e.key === "Enter") {
-                    e.stopPropagation();
-                    if (!e.shiftKey) {
-                      e.preventDefault();
-                      if (formValidator()) submitHandler(e as unknown as FormEvent, handleClearForm, selectedData);
-                    }
+      {/* Compose bar: comment + time + billable + submit */}
+      <form
+        onSubmit={(e) => submitHandler(e, handleClearForm, selectedData)}
+        onKeyDown={(e) => e.key === "Enter" && formValidator() && submitHandler(e, handleClearForm, selectedData)}
+        autoComplete="off"
+        className="border-t"
+      >
+        <div className="flex flex-col gap-2 p-3 sm:px-4">
+          {/* Row 1: comment input */}
+          <div className="flex min-h-[52px] items-start rounded-md border bg-background px-2 py-2 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary">
+            <MessageSquare className="mt-1 shrink-0 text-muted-foreground" size={16} />
+            <textarea
+              rows={2}
+              className="min-h-[36px] w-full resize-y border-0 bg-transparent px-2 py-0.5 text-sm focus:outline-0 focus:ring-0"
+              placeholder="Add a comment..."
+              value={selectedData?.comment ?? ""}
+              onChange={(e) => setCommentText(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter submits; Shift+Enter adds a newline.
+                // Stop propagation so the form-level Enter handler doesn't also fire.
+                if (e.key === "Enter") {
+                  e.stopPropagation();
+                  if (!e.shiftKey) {
+                    e.preventDefault();
+                    if (formValidator()) submitHandler(e as unknown as FormEvent, handleClearForm, selectedData);
                   }
-                }}
-              />
-            </div>
+                }
+              }}
+            />
+          </div>
 
             {/* Row 2: time controls + reset ... billable + submit */}
             <div className="flex flex-wrap items-center gap-2">
@@ -536,7 +536,6 @@ export const TimeLogBoard = ({ projects, edit, submitHandler, recent, draft, onD
             </div>
           </div>
         </form>
-      </div>
     </div>
   );
 };

--- a/components/forms/timelogForm.tsx
+++ b/components/forms/timelogForm.tsx
@@ -308,7 +308,7 @@ export const TimeLogForm = ({ projects, edit, submitHandler, recent, draft, onDr
                 tabIndex={selectedData?.project && selectedData?.comment && selectedData?.time ? 7 : -1}
                 className="disabled:disabled border disabled:hover:bg-primary"
               >
-                {edit.isEditing ? "Update" : "Submit"}
+                {edit.isEditing ? "Save" : "Add"}
               </Button>
             </span>
           </div>

--- a/components/inline-date-picker.tsx
+++ b/components/inline-date-picker.tsx
@@ -25,15 +25,27 @@ export const InlineDatePicker = ({ date, setDate, dayTotalTime }: InlineDateProp
 
   return (
     <div className="flex w-full items-center gap-2">
-      <div className="flex min-w-0 flex-1 items-center justify-center gap-2">
-        <div className="flex items-center">
+      <div className="flex min-w-0 flex-1 items-center justify-center">
+        <div className="flex h-9 items-stretch">
+          <span className="relative text-sm font-medium tracking-tighter">
+            <ClassicDatePicker date={date} setDate={setDate} className="h-full rounded-r-none border-r-0">
+              {getDateString(date)}
+              {dayTotalTime != null && dayTotalTime > 0 ? (
+                <span
+                  aria-hidden
+                  title={`${dayTotalTime.toFixed(2)}h logged`}
+                  className={cn("absolute -top-1 -right-1 size-2.5 rounded-full", getDayHoursTone(dayTotalTime))}
+                />
+              ) : null}
+            </ClassicDatePicker>
+          </span>
           <Button
             variant="outline"
             size="icon"
             onClick={() => goToDate(-1)}
             aria-label="Previous day"
             title="Previous day"
-            className="rounded-r-none border-r-0"
+            className="h-full w-9 shrink-0 rounded-none border-r-0"
           >
             <ChevronLeft size={20} />
           </Button>
@@ -46,24 +58,11 @@ export const InlineDatePicker = ({ date, setDate, dayTotalTime }: InlineDateProp
             disabled={!isNextClickable}
             aria-label="Next day"
             title="Next day"
-            className="rounded-l-none"
+            className="h-full w-9 shrink-0 rounded-l-none"
           >
             <ChevronRight size={20} />
           </Button>
         </div>
-
-        <span className="relative text-sm font-medium tracking-tighter">
-          <ClassicDatePicker date={date} setDate={setDate}>
-            {getDateString(date)}
-            {dayTotalTime != null && dayTotalTime > 0 ? (
-              <span
-                aria-hidden
-                title={`${dayTotalTime.toFixed(2)}h logged`}
-                className={cn("absolute -top-1 -right-1 size-2.5 rounded-full", getDayHoursTone(dayTotalTime))}
-              />
-            ) : null}
-          </ClassicDatePicker>
-        </span>
       </div>
 
       <Button
@@ -73,7 +72,7 @@ export const InlineDatePicker = ({ date, setDate, dayTotalTime }: InlineDateProp
         title="Go to today"
         tabIndex={showToday ? undefined : -1}
         aria-hidden={!showToday}
-        className={cn("shrink-0 transition-opacity", showToday ? "opacity-100" : "pointer-events-none opacity-0")}
+        className={cn("h-9 shrink-0 transition-opacity", showToday ? "opacity-100" : "pointer-events-none opacity-0")}
       >
         <Redo2 size={16} />
         <span className="ml-1 hidden sm:inline">Today</span>

--- a/components/time-entries-list.tsx
+++ b/components/time-entries-list.tsx
@@ -31,8 +31,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./ui/dialog";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+
 import { toast } from "sonner";
+import { CustomTooltip } from "./custom/tooltip";
 
 interface TimeEntries {
   entries: TimeEntryDataObj;
@@ -53,7 +54,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                 className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
                 style={{ backgroundColor: getRandomColor(entryData.project.id) }}
               >
-                {entryData.project.name.charAt(0)}
+                {entryData.project.client?.name?.charAt(0) ?? entryData.project.name.charAt(0)}
               </span>
               <span
                 className="min-w-0 truncate"
@@ -89,7 +90,6 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
             const isEditable = entryData.project.status !== "ARCHIVED";
             const messageFor = entryData.project.status === "ARCHIVED" ? "Project" : "";
             const isLastEntry = i === entryData.data.length - 1;
-            const isLastProject = projectIndex === entries.projectsLog!.length - 1;
             const hasMeta = Boolean(data.milestone?.name || data.task?.name);
 
             return (
@@ -98,7 +98,6 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                   className={cn(
                     "group bg-secondary relative flex justify-between gap-3 px-5 py-2",
                     isEditing && "ring-muted-foreground ring-1 ring-inset",
-                    isLastProject && isLastEntry && "rounded-b-xl",
                   )}
                 >
                   <div className={cn("flex min-w-0 flex-1 flex-col gap-y-2", !hasMeta && "justify-end")}>
@@ -137,7 +136,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                     </p>
                   </div>
 
-                  <div className="flex min-w-[100px] shrink-0 flex-col justify-between text-right select-none">
+                  <div className="flex min-w-25 shrink-0 flex-col justify-between text-right select-none">
                     <div className="flex items-center justify-end gap-1.5">
                       <div
                         className={cn(
@@ -146,8 +145,8 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                           isEditing && "md:opacity-100",
                         )}
                       >
-                        <Tooltip>
-                          <TooltipTrigger asChild>
+                        <CustomTooltip
+                          trigger={
                             <Button
                               type="button"
                               variant="outline"
@@ -161,14 +160,14 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                             >
                               {isEditing ? <ListRestart size={14} /> : <Edit size={14} />}
                             </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>{isEditing ? "Cancel edit" : "Edit"}</TooltipContent>
-                        </Tooltip>
+                          }
+                          content={isEditing ? "Cancel edit" : "Edit"}
+                        />
 
                         {isEditable ? (
                           <Dialog>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
+                            <CustomTooltip
+                              trigger={
                                 <DialogTrigger asChild>
                                   <Button
                                     type="button"
@@ -180,10 +179,10 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                                     <Trash size={14} />
                                   </Button>
                                 </DialogTrigger>
-                              </TooltipTrigger>
-                              <TooltipContent>Delete</TooltipContent>
-                            </Tooltip>
-                            <DialogContent className="sm:max-w-[425px]">
+                              }
+                              content="Delete"
+                            />
+                            <DialogContent className="sm:max-w-106.25">
                               <DialogHeader>
                                 <DialogTitle>Are you sure to delete this time entry?</DialogTitle>
                                 <DialogDescription>
@@ -218,16 +217,16 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                       </span>
                     </div>
 
-                    {data.billable ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                    {data.billable && (
+                      <CustomTooltip
+                        trigger={
                           <span className="text-success ml-auto inline-flex" aria-label="Billable">
                             <CircleDollarSign size={16} />
                           </span>
-                        </TooltipTrigger>
-                        <TooltipContent>Billable</TooltipContent>
-                      </Tooltip>
-                    ) : null}
+                        }
+                        content="Billable"
+                      />
+                    )}
                   </div>
                 </div>
                 {!isLastEntry ? <Separator /> : null}
@@ -260,30 +259,28 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
       <div className="mb-2 flex flex-col gap-2">
         <div className="flex justify-between">
           <Skeleton className="h-6 w-1/4" />
-          <Skeleton className="h-6 w-[80px]" />
+          <Skeleton className="h-6 w-20" />
         </div>
       </div>
       <div className="flex flex-col gap-2">
         <div className="flex justify-between">
           <Skeleton className="h-6 w-3/4" />
-          <Skeleton className="h-6 w-[80px]" />
+          <Skeleton className="h-6 w-20" />
         </div>
       </div>
     </li>
   );
 
   return (
-    <TooltipProvider delayDuration={200}>
-      <ul
-        className={cn(
-          "flex w-full flex-col overflow-y-auto",
-          entries.projectsLog?.length && "max-h-none sm:max-h-[calc(100vh-306px)]",
-        )}
-      >
-        {status === "loading" && skeletonLoader}
-        {status === "success" && renderEntries}
-        {status === "error" && <li className="text-destructive p-4 text-center text-sm">Something went wrong</li>}
-      </ul>
-    </TooltipProvider>
+    <ul
+      className={cn(
+        "flex w-full flex-col overflow-y-auto",
+        entries.projectsLog?.length && "max-h-none sm:max-h-[calc(100vh-306px)]",
+      )}
+    >
+      {status === "loading" && skeletonLoader}
+      {status === "success" && renderEntries}
+      {status === "error" && <li className="text-destructive p-4 text-center text-sm">Something went wrong</li>}
+    </ul>
   );
 };

--- a/components/time-entries-list.tsx
+++ b/components/time-entries-list.tsx
@@ -130,7 +130,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
                       title={data.comments ?? undefined}
                     >
                       <MessageSquare size={12} className="mt-0.5 mr-1 shrink-0 opacity-70" />
-                      <span className="min-w-0 flex-1">
+                      <span className="min-w-0 flex-1 wrap-break-word whitespace-pre-wrap">
                         {data.comments?.trim() || <span className="italic opacity-70">No comment added</span>}
                       </span>
                     </p>

--- a/components/time-entries-list.tsx
+++ b/components/time-entries-list.tsx
@@ -41,32 +41,60 @@ interface TimeEntries {
   deleteEntryHandler: (id: number) => void;
   editEntryHandler: (obj: SelectedData, id: number) => void;
   edit: EditReferenceObj;
+  /** Board right panel: grow and scroll within the available viewport height */
+  fillHeight?: boolean;
 }
 
-export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntryHandler, edit }: TimeEntries) => {
+export const TimeEntriesList = ({
+  entries,
+  status,
+  deleteEntryHandler,
+  editEntryHandler,
+  edit,
+  fillHeight = false,
+}: TimeEntries) => {
   const renderEntries = Array.isArray(entries.projectsLog) ? (
     entries.projectsLog.map((entryData, projectIndex) => (
       <li key={entryData.project.id}>
-        <Card className="overflow-hidden rounded-none border-x-0 border-t border-b-0 shadow-none">
-          <div className="flex w-full items-center justify-between gap-3 px-5 py-2">
-            <p className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <Card
+          className={cn(
+            "overflow-hidden rounded-none border-x-0 border-b-0 shadow-none",
+            // Day total already provides the top rule in board fill-height mode
+            fillHeight && projectIndex === 0 ? "border-t-0" : "border-t",
+          )}
+        >
+          <div
+            className={cn(
+              "flex w-full items-start justify-between gap-2",
+              fillHeight ? "px-3 py-2.5" : "px-5 py-2",
+            )}
+          >
+            <div className="flex min-w-0 flex-1 items-start gap-2">
               <span
-                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
+                className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
                 style={{ backgroundColor: getRandomColor(entryData.project.id) }}
               >
                 {entryData.project.client?.name?.charAt(0) ?? entryData.project.name.charAt(0)}
               </span>
-              <span
-                className="min-w-0 truncate"
-                title={`${entryData.project.name} - ${entryData.project.client?.name}`}
+              <div
+                className="min-w-0 flex-1"
+                title={
+                  entryData.project.client?.name
+                    ? `${entryData.project.name} · ${entryData.project.client.name}`
+                    : entryData.project.name
+                }
               >
-                {entryData.project.name}
+                <p className="text-sm leading-snug font-medium wrap-break-word">{entryData.project.name}</p>
                 {entryData.project.client?.name ? (
-                  <span className="text-muted-foreground text-xs font-normal"> · {entryData.project.client.name}</span>
+                  <p className="text-muted-foreground text-xs leading-snug wrap-break-word">
+                    {entryData.project.client.name}
+                  </p>
                 ) : null}
-              </span>
-            </p>
-            <span className="shrink-0 text-sm font-semibold tabular-nums">{entryData.total.toFixed(2)} h</span>
+              </div>
+            </div>
+            <span className="shrink-0 pt-0.5 text-sm font-semibold tabular-nums">
+              {entryData.total.toFixed(2)} h
+            </span>
           </div>
 
           <Separator />
@@ -237,7 +265,12 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
       </li>
     ))
   ) : (
-    <li className="flex flex-col items-center justify-center space-y-3 border-t px-6 py-14 text-center sm:py-16">
+    <li
+      className={cn(
+        "flex flex-col items-center justify-center space-y-3 px-6 py-14 text-center sm:py-16",
+        fillHeight ? "min-h-0 flex-1" : "border-t",
+      )}
+    >
       <div className="bg-muted flex h-14 w-14 items-center justify-center rounded-full">
         <CalendarClock size={28} className="text-muted-foreground" />
       </div>
@@ -251,7 +284,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
   );
 
   const skeletonLoader = (
-    <li className="border-t p-2">
+    <li className={cn("p-2", !fillHeight && "border-t")}>
       <div className="mb-2 flex items-center justify-between gap-4">
         <Skeleton className="h-6 w-3/4" />
         <Skeleton className="h-6 w-1/4" />
@@ -275,7 +308,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
     <ul
       className={cn(
         "flex w-full flex-col overflow-y-auto",
-        entries.projectsLog?.length && "max-h-none sm:max-h-[calc(100vh-306px)]",
+        fillHeight ? "min-h-0 flex-1" : entries.projectsLog?.length && "max-h-none sm:max-h-[calc(100vh-306px)]",
       )}
     >
       {status === "loading" && skeletonLoader}

--- a/components/time-entries-list.tsx
+++ b/components/time-entries-list.tsx
@@ -238,7 +238,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
       </li>
     ))
   ) : (
-    <li className="flex flex-col items-center justify-center space-y-3 px-6 py-14 text-center sm:py-16">
+    <li className="flex flex-col items-center justify-center space-y-3 border-t px-6 py-14 text-center sm:py-16">
       <div className="bg-muted flex h-14 w-14 items-center justify-center rounded-full">
         <CalendarClock size={28} className="text-muted-foreground" />
       </div>
@@ -252,7 +252,7 @@ export const TimeEntriesList = ({ entries, status, deleteEntryHandler, editEntry
   );
 
   const skeletonLoader = (
-    <li className="p-2">
+    <li className="border-t p-2">
       <div className="mb-2 flex items-center justify-between gap-4">
         <Skeleton className="h-6 w-3/4" />
         <Skeleton className="h-6 w-1/4" />

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -90,9 +90,10 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   // Wait for persist rehydration so we don't flash classic → board (or vice versa).
   const showBoard = hasHydrated && logBoardView;
 
-  // This sets the AI input from the local storage
   useEffect(() => {
-    setAiInput(localStorage?.getItem("notebook-input") || "");
+    setTimeout(() => {
+      setAiInput(localStorage?.getItem("notebook-input") || "");
+    }, 0);
   }, []);
 
   const editEntryHandler = (obj: SelectedData, id: number) => {
@@ -197,7 +198,9 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
 
   useEffect(() => {
     if (!edit.isEditing) {
-      getTimeEntries();
+      setTimeout(() => {
+        getTimeEntries();
+      }, 0);
     }
   }, [getTimeEntries, edit.isEditing]);
 
@@ -330,7 +333,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
             </div>
           </div>
           {!hasHydrated ? (
-            <div className="min-h-[280px] animate-pulse bg-muted/40" aria-hidden />
+            <div className="bg-muted/40 min-h-70 animate-pulse" aria-hidden />
           ) : showBoard ? (
             <TimeLogBoard
               projects={projects}

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, FormEvent, useMemo, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { format } from "date-fns";
 import { useRouter } from "next/navigation";
@@ -22,6 +23,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import AINotepad from "./ai/notepad";
 import NotepadResponse from "./ai/notepad-response";
 import { hoursToDecimal } from "@/lib/helper";
+import { getRandomColor } from "@/lib/random-colors";
 import { generateId } from "ai";
 import { isTimelogValid } from "@/lib/timelog-validation";
 
@@ -206,6 +208,16 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
 
   const dayTotalTime = useMemo(() => entries.data.dayTotal, [entries.data]);
 
+  const [notebookSlot, setNotebookSlot] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!showBoard) {
+      setNotebookSlot(null);
+      return;
+    }
+    setNotebookSlot(document.getElementById("board-notebook-slot"));
+  }, [showBoard]);
+
   /*
    * handleRecentClick: The following function adds recent state for adding new entry
    */
@@ -282,67 +294,170 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
     }
   };
 
+  const boardNotebook = (
+    <div className="flex flex-col gap-4">
+      <AINotepad
+        defaultOpen
+        compact
+        notebookSubmitHandler={notebookSubmitHandler}
+        aiInput={aiInput}
+        setAiInput={setAiInput}
+        aiLoading={aiLoading}
+      />
+      <NotepadResponse
+        aiResponses={aiResponses}
+        setAiResponses={setAiResponses}
+        projects={projects}
+        handleSubmit={submitTimeEntry}
+        handleSubmitAll={submitAllTimeEntries}
+      />
+    </div>
+  );
+
+  const viewToggle = (
+    <div
+      role="group"
+      aria-label="Logger view"
+      className={cn(
+        "bg-background flex shrink-0 items-center gap-0.5 rounded-md border p-0.5",
+        !hasHydrated && "pointer-events-none opacity-60",
+      )}
+    >
+      {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
+        <Tooltip key={label}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setLogBoardView(board)}
+              aria-label={label}
+              aria-pressed={hasHydrated ? showBoard === board : undefined}
+              disabled={!hasHydrated}
+              className={cn(
+                "relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm transition-colors disabled:cursor-default",
+                hasHydrated && showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
+              )}
+            >
+              <Icon size={16} />
+              {isNew && (
+                <span className="bg-brand-fuchsia absolute -top-0.5 -right-0.5 flex h-3 w-3 items-center justify-center rounded-full text-white">
+                  <Sparkles size={8} />
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{label}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+
+  const datePicker = (
+    <InlineDatePicker
+      date={date}
+      setDate={(newDate: Date) => {
+        router.push(`?date=${format(newDate, "yyyy-MM-dd")}`);
+      }}
+      dayTotalTime={dayTotalTime}
+    />
+  );
+
+  const entriesList = (fillHeight = false) => (
+    <TimeEntriesList
+      entries={entries.data}
+      status={entries.status}
+      deleteEntryHandler={deleteTimeEntry}
+      editEntryHandler={editEntryHandler}
+      edit={edit}
+      fillHeight={fillHeight}
+    />
+  );
+
+  // Recommended B: form+recent | day list | hours+heatmap+notebook (aside)
+  if (showBoard) {
+    return (
+      <>
+        <div className="grid w-full grid-cols-12 items-start gap-4">
+          <div className="col-span-12 lg:col-span-7">
+            <Card className="overflow-hidden shadow-none">
+              <div className="flex items-center gap-2 border-b p-2">
+                {viewToggle}
+                <div className="min-w-0 flex-1">{datePicker}</div>
+              </div>
+              <TimeLogBoard
+                projects={projects}
+                edit={edit}
+                recent={recent}
+                submitHandler={submitTimeEntry}
+                draft={draft}
+                onDraftChange={setDraft}
+              />
+            </Card>
+          </div>
+
+          <div className="col-span-12 flex min-h-0 flex-col gap-4 lg:col-span-5">
+            <div className="flex min-h-0 flex-col gap-4 lg:sticky lg:top-[4.5rem] lg:max-h-[calc(100vh-7.5rem)]">
+              {recentTimeEntries.length > 0 && (
+                <section className="border-border bg-card shrink-0 rounded-lg border p-4">
+                  <div className="mb-3">
+                    <h2 className="text-sm font-medium">Recently used</h2>
+                    <p className="text-muted-foreground text-[11px]">Tap to quick-fill the form</p>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {recentTimeEntries.slice(0, 5).map((entry) => (
+                      <button
+                        key={entry.id}
+                        type="button"
+                        onClick={() => handleRecentClick(entry)}
+                        title={
+                          [entry.project?.client?.name, entry.project?.name, entry.milestone?.name, entry.task?.name]
+                            .filter(Boolean)
+                            .join(" · ") || entry.project?.name
+                        }
+                        className="border-border text-foreground hover:bg-muted inline-flex h-7 max-w-full cursor-pointer items-center gap-1.5 rounded-full border py-0 pl-1 pr-2.5 text-left text-xs leading-none transition-colors"
+                      >
+                        <span
+                          className="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium leading-none text-white"
+                          style={entry.project?.id ? { backgroundColor: getRandomColor(entry.project.id) } : undefined}
+                          aria-hidden
+                        >
+                          {entry.project?.client?.name?.charAt(0) ?? "?"}
+                        </span>
+                        <span className="truncate leading-none">{entry.project?.name}</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              <Card className="flex min-h-0 w-full flex-1 flex-col overflow-hidden shadow-none">
+                <div className="border-border flex shrink-0 items-center justify-between gap-3 border-b px-4 py-2.5 sm:px-5">
+                  <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Day total</p>
+                  <span className="text-sm font-semibold tabular-nums">
+                    {dayTotalTime ? `${dayTotalTime.toFixed(2)} h` : "0.00 h"}
+                  </span>
+                </div>
+                {entriesList(true)}
+              </Card>
+            </div>
+          </div>
+        </div>
+
+        {notebookSlot ? createPortal(boardNotebook, notebookSlot) : null}
+      </>
+    );
+  }
+
+  // Classic layout (unchanged structure)
   return (
     <div className="grid w-full grid-cols-12 items-start gap-4">
       <div className="col-span-12 md:col-span-8">
         <Card className="overflow-hidden shadow-none">
           <div className="flex items-center gap-2 border-b p-2">
-            {/* View switcher — sits in the card header so it never clips outside the content box */}
-            <div
-              role="group"
-              aria-label="Logger view"
-              className={cn(
-                "bg-background flex shrink-0 items-center gap-0.5 rounded-md border p-0.5",
-                !hasHydrated && "pointer-events-none opacity-60",
-              )}
-            >
-              {LOGGER_VIEWS.map(({ board, label, Icon, isNew }) => (
-                <Tooltip key={label}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => setLogBoardView(board)}
-                      aria-label={label}
-                      aria-pressed={hasHydrated ? showBoard === board : undefined}
-                      disabled={!hasHydrated}
-                      className={cn(
-                        "relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm transition-colors disabled:cursor-default",
-                        hasHydrated && showBoard === board ? VIEW_TOGGLE_ACTIVE : VIEW_TOGGLE_INACTIVE,
-                      )}
-                    >
-                      <Icon size={16} />
-                      {isNew && (
-                        <span className="bg-brand-fuchsia absolute -top-0.5 -right-0.5 flex h-3 w-3 items-center justify-center rounded-full text-white">
-                          <Sparkles size={8} />
-                        </span>
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{label}</TooltipContent>
-                </Tooltip>
-              ))}
-            </div>
-            <div className="min-w-0 flex-1">
-              <InlineDatePicker
-                date={date}
-                setDate={(newDate: Date) => {
-                  router.push(`?date=${format(newDate, "yyyy-MM-dd")}`);
-                }}
-                dayTotalTime={dayTotalTime}
-              />
-            </div>
+            {viewToggle}
+            <div className="min-w-0 flex-1">{datePicker}</div>
           </div>
           {!hasHydrated ? (
             <div className="bg-muted/40 min-h-70 animate-pulse" aria-hidden />
-          ) : showBoard ? (
-            <TimeLogBoard
-              projects={projects}
-              edit={edit}
-              recent={recent}
-              submitHandler={submitTimeEntry}
-              draft={draft}
-              onDraftChange={setDraft}
-            />
           ) : (
             <TimeLogForm
               projects={projects}
@@ -359,13 +474,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
               <span className="text-sm font-semibold tabular-nums">{dayTotalTime.toFixed(2)} h</span>
             </div>
           )}
-          <TimeEntriesList
-            entries={entries.data}
-            status={entries.status}
-            deleteEntryHandler={deleteTimeEntry}
-            editEntryHandler={editEntryHandler}
-            edit={edit}
-          />
+          {entriesList(false)}
         </Card>
       </div>
       <div className="col-span-12 flex flex-col gap-4 md:col-span-4">

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -295,7 +295,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   };
 
   const boardNotebook = (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-2.5">
       <AINotepad
         defaultOpen
         compact
@@ -376,7 +376,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
   if (showBoard) {
     return (
       <>
-        <div className="grid w-full grid-cols-12 items-start gap-4">
+        <div className="grid w-full grid-cols-12 items-start gap-2.5">
           <div className="col-span-12 lg:col-span-7">
             <Card className="overflow-hidden shadow-none">
               <div className="flex items-center gap-2 border-b p-2">
@@ -394,8 +394,8 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
             </Card>
           </div>
 
-          <div className="col-span-12 flex min-h-0 flex-col gap-4 lg:col-span-5">
-            <div className="flex min-h-0 flex-col gap-4 lg:sticky lg:top-[4.5rem] lg:max-h-[calc(100vh-7.5rem)]">
+          <div className="col-span-12 flex min-h-0 flex-col gap-2.5 lg:col-span-5">
+            <div className="flex min-h-0 flex-col gap-2.5 lg:sticky lg:top-[4.5rem] lg:max-h-[calc(100vh-7.5rem)]">
               {recentTimeEntries.length > 0 && (
                 <section className="border-border bg-card shrink-0 rounded-lg border p-4">
                   <div className="mb-3">
@@ -430,7 +430,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
               )}
 
               <Card className="flex min-h-0 w-full flex-1 flex-col overflow-hidden shadow-none">
-                <div className="border-border flex shrink-0 items-center justify-between gap-3 border-b px-4 py-2.5 sm:px-5">
+                <div className="border-border flex shrink-0 items-center justify-between gap-2 border-b px-4 py-2.5 sm:px-5">
                   <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Day total</p>
                   <span className="text-sm font-semibold tabular-nums">
                     {dayTotalTime ? `${dayTotalTime.toFixed(2)} h` : "0.00 h"}
@@ -449,7 +449,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
 
   // Classic layout (unchanged structure)
   return (
-    <div className="grid w-full grid-cols-12 items-start gap-4">
+    <div className="grid w-full grid-cols-12 items-start gap-2.5">
       <div className="col-span-12 md:col-span-8">
         <Card className="overflow-hidden shadow-none">
           <div className="flex items-center gap-2 border-b p-2">
@@ -469,7 +469,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
             />
           )}
           {!!dayTotalTime && (
-            <div className="border-border flex items-center justify-between gap-3 border-t px-4 py-2.5 sm:px-5">
+            <div className="border-border flex items-center justify-between gap-2 border-t px-4 py-2.5 sm:px-5">
               <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Day total</p>
               <span className="text-sm font-semibold tabular-nums">{dayTotalTime.toFixed(2)} h</span>
             </div>
@@ -477,7 +477,7 @@ export const TimeEntry = ({ team, projects, recentTimeEntries, initialDate }: Ti
           {entriesList(false)}
         </Card>
       </div>
-      <div className="col-span-12 flex flex-col gap-4 md:col-span-4">
+      <div className="col-span-12 flex flex-col gap-2.5 md:col-span-4">
         <RecentEntries recentTimeEntries={recentTimeEntries} handleRecentClick={handleRecentClick} />
         <AINotepad
           notebookSubmitHandler={notebookSubmitHandler}


### PR DESCRIPTION
## Summary
- Restructures the new timesheet board into form + day list, with hours logged, heatmap, and notebook available in the home aside on all screen sizes (not desktop-only).
- Moves recently used into its own card matching the hours/heatmap styling, with pill chips for quick-fill.
- Polishes date navigation by attaching prev/next to the calendar control, and tightens list/comment/border and notebook outline details.

## Test plan
- [x] Open team home in **New Timesheet** view on desktop and mobile — confirm hours logged, heatmap, recently used, day list, and notebook all render
- [x] Quick-fill from a recently used pill and confirm the form updates; clear/reset should not leave a stuck “active” chip
- [x] Day list scrolls within the column without pushing the page past the viewport on desktop
- [x] Date header: calendar + prev/next share one aligned control; Today still jumps to today
- [x] Switch to Classic view and confirm layout/aside still work as expected
- [x] Notebook accordion: textarea outline is not clipped when expanded


Made with [Cursor](https://cursor.com)