### PR TITLE
feat: Multi-theme color system

### DIFF
--- a/app/[team]/(reports)/reports/leaves/leave-details.tsx
+++ b/app/[team]/(reports)/reports/leaves/leave-details.tsx
@@ -95,7 +95,7 @@ function LeaveDetails({ leave, updatedAt }: { leave: LeaveDetailsType; updatedAt
                         data={chartData}
                         category="value"
                         index="name"
-                        colors={isOverused ? ["rose", "slate"] : ["zinc", "emerald"]}
+                        colors={isOverused ? ["rose", "lilac"] : ["lilac", "fuchsia"]}
                         showAnimation
                         variant="pie"
                       />

--- a/app/[team]/(reports)/reports/leaves/manage/columns.tsx
+++ b/app/[team]/(reports)/reports/leaves/manage/columns.tsx
@@ -147,7 +147,7 @@ const UserCell = ({ user }: { user: User }) => {
 
   return (
     <Link href={`/${team}/reports/leaves?member=${user.id}`} className="flex items-center gap-x-2">
-      <UserAvatar user={user} className="z-10 mr-2 inline-block h-8 w-8 bg-slate-300" />
+      <UserAvatar user={user} className="bg-secondary z-10 mr-2 inline-block h-8 w-8" />
       <span className="min-w-[150px]">{user.name}</span>
     </Link>
   );

--- a/app/[team]/(reports)/reports/logged/columns.tsx
+++ b/app/[team]/(reports)/reports/logged/columns.tsx
@@ -182,7 +182,7 @@ export const columns: ColumnDef<Logged>[] = [
             <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
               <UserAvatar
                 user={{ name: original.name ?? null, image: original.image ?? null }}
-                className="h-6 w-6 shrink-0 bg-slate-300"
+                className="bg-secondary h-6 w-6 shrink-0"
               />
               <span className="min-w-0 flex-1 truncate">{value}</span>
               <MemberGroups groups={original.groups ?? []} />

--- a/app/[team]/(reports)/reports/logged/toolbar.tsx
+++ b/app/[team]/(reports)/reports/logged/toolbar.tsx
@@ -158,8 +158,8 @@ export function DataTableToolbar<TData>({
         size={18}
         className={cn(
           selectedBilling === "true" && "text-success hover:text-success focus:bg-success/10",
-          selectedBilling === "false" && "text-slate-400",
-          !selectedBilling && "text-black dark:text-white",
+          selectedBilling === "false" && "text-muted-foreground",
+          !selectedBilling && "text-foreground",
         )}
       />
       {generateBillingQuery()?.text}

--- a/app/[team]/members/columns.tsx
+++ b/app/[team]/members/columns.tsx
@@ -39,7 +39,7 @@ export const getColumn = ({ updateStatus, userGroup, updateUserGroup }: GetColum
                 name: row.original.name ? row.original.name : "",
                 image: row.original.image ? row.original.image : "",
               }}
-              className="z-10 mr-2 inline-block h-6 w-6 bg-slate-300"
+              className="bg-secondary z-10 mr-2 inline-block h-6 w-6"
             />
             <span>{row.original.name}</span>
           </div>

--- a/app/[team]/projects/[project]/(projects)/members/columns.tsx
+++ b/app/[team]/projects/[project]/(projects)/members/columns.tsx
@@ -48,7 +48,7 @@ export const getColumn = ({ removeMember }: GetColumn) => {
                 name: row.original.name ?? "",
                 image: row.original.image ?? "",
               }}
-              className="z-10 mr-2 inline-block h-6 w-6 bg-slate-300"
+              className="bg-secondary z-10 mr-2 inline-block h-6 w-6"
             />
             <span className="cursor-default">{row.original.name}</span>
           </div>

--- a/app/[team]/projects/[project]/components/columns.tsx
+++ b/app/[team]/projects/[project]/components/columns.tsx
@@ -98,7 +98,7 @@ export const getColumns = (
             {depth === 0 && (
               <UserAvatar
                 user={{ name: row.original.name ?? null, image: row.original.image ?? null }}
-                className="h-6 w-6 bg-slate-300"
+                className="bg-secondary h-6 w-6"
               />
             )}
             <span className={`${depth === 1 ? "w-[150px]" : "w-full"} line-clamp-1 shrink-0`}>{value}</span>

--- a/app/[team]/projects/[project]/components/project-edit-combobox.tsx
+++ b/app/[team]/projects/[project]/components/project-edit-combobox.tsx
@@ -109,7 +109,7 @@ export function ProjectEditComboBox({
       >
         <Command className="border-border box-border rounded-t-[5px] border">
           <div className="border-border flex w-full items-center rounded-t-[5px] border-b">
-            <Search size={16} className="ml-[10px] text-gray-400" />
+            <Search size={16} className="text-muted-foreground ml-[10px]" />
             <input
               className="bg-popover m-1 box-border h-9 w-full rounded-none border-0 pr-2.5 pl-1.5 text-sm focus:outline-hidden"
               autoFocus

--- a/app/[team]/projects/[project]/components/time-chart.tsx
+++ b/app/[team]/projects/[project]/components/time-chart.tsx
@@ -84,7 +84,7 @@ function ChartTooltip({
   const dateLabel = isMonthlyView ? format(new Date(label), "MMMM yyyy") : format(new Date(label), "EEE, dd MMM, yyyy");
 
   return (
-    <div className="border-border bg-primary-foreground rounded-md border p-2 text-xs shadow-xs">
+    <div className="border-border bg-popover rounded-md border p-2 text-xs shadow-xs">
       <p className="label">{dateLabel}</p>
       <p className="desc">Hours logged: {payload[0].value}h</p>
     </div>

--- a/app/[team]/projects/[project]/components/toolbar.tsx
+++ b/app/[team]/projects/[project]/components/toolbar.tsx
@@ -151,8 +151,8 @@ export function DataTableToolbar({
           size={18}
           className={cn(
             selectedBilling === "true" && "text-success hover:text-success focus:bg-success/10",
-            selectedBilling === "false" && "text-slate-400",
-            !selectedBilling && "text-black dark:text-white",
+            selectedBilling === "false" && "text-muted-foreground",
+            !selectedBilling && "text-foreground",
           )}
         />
         {generateBillingQuery()?.text}

--- a/app/[team]/projects/columns.tsx
+++ b/app/[team]/projects/columns.tsx
@@ -151,7 +151,7 @@ export const columns: ColumnDef<Projects>[] = [
               name: owner,
               image: row.original.ownerImage ?? "",
             }}
-            className="h-6 w-6 shrink-0 bg-slate-300"
+            className="bg-secondary h-6 w-6 shrink-0"
           />
           <span className="truncate text-sm">{owner}</span>
         </div>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -163,8 +163,8 @@ function SignInForm() {
 
       {/* Background decoration */}
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-        <div className="absolute left-1/4 top-0 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
-        <div className="absolute bottom-0 right-1/4 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
+        <div className="bg-brand-fuchsia/10 absolute top-0 left-1/4 h-96 w-96 rounded-full blur-3xl" />
+        <div className="bg-brand-eggplant/10 dark:bg-brand-lilac/10 absolute right-1/4 bottom-0 h-96 w-96 rounded-full blur-3xl" />
       </div>
     </div>
   );

--- a/app/auth/verify-request/page.tsx
+++ b/app/auth/verify-request/page.tsx
@@ -102,8 +102,8 @@ export default async function VerifyRequest() {
 
       {/* Background decoration */}
       <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-        <div className="absolute left-1/4 top-0 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
-        <div className="absolute bottom-0 right-1/4 h-96 w-96 rounded-full bg-primary/5 blur-3xl" />
+        <div className="bg-brand-fuchsia/10 absolute top-0 left-1/4 h-96 w-96 rounded-full blur-3xl" />
+        <div className="bg-brand-eggplant/10 dark:bg-brand-lilac/10 absolute right-1/4 bottom-0 h-96 w-96 rounded-full blur-3xl" />
       </div>
     </div>
   );

--- a/app/color-theme-provider.tsx
+++ b/app/color-theme-provider.tsx
@@ -12,19 +12,30 @@ import {
 
 import {
   COLOR_THEME_STORAGE_KEY,
-  COLOR_THEMES,
   DEFAULT_COLOR_THEME,
   getColorTheme,
+  getPresetThemes,
   isColorThemeId,
   type ColorThemeId,
   type ColorThemeMeta,
 } from "@/lib/color-themes";
+import {
+  CUSTOM_THEME_STORAGE_KEY,
+  DEFAULT_CUSTOM_PRIMARY,
+  injectCustomThemeStyle,
+  persistCustomTheme,
+  readStoredCustomTheme,
+  type CustomThemeConfig,
+} from "@/lib/generate-theme";
 
 interface ColorThemeContextValue {
   theme: ColorThemeId;
   setTheme: (theme: ColorThemeId) => void;
   themes: ColorThemeMeta[];
   activeTheme: ColorThemeMeta;
+  customConfig: CustomThemeConfig;
+  setCustomConfig: (config: CustomThemeConfig, options?: { activate?: boolean }) => void;
+  resetCustomConfig: () => void;
 }
 
 const ColorThemeContext = createContext<ColorThemeContextValue | null>(null);
@@ -35,28 +46,62 @@ function applyColorTheme(theme: ColorThemeId) {
 
 export function ColorThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<ColorThemeId>(DEFAULT_COLOR_THEME);
+  const [customConfig, setCustomConfigState] = useState<CustomThemeConfig>({
+    primary: DEFAULT_CUSTOM_PRIMARY,
+  });
 
   useEffect(() => {
     const stored = localStorage.getItem(COLOR_THEME_STORAGE_KEY);
     const next = isColorThemeId(stored) ? stored : DEFAULT_COLOR_THEME;
+    const custom = readStoredCustomTheme();
+    setCustomConfigState(custom);
+
+    const css = localStorage.getItem(`${CUSTOM_THEME_STORAGE_KEY}-css`);
+    if (css) injectCustomThemeStyle(css);
+    else persistCustomTheme(custom);
+
     setThemeState(next);
     applyColorTheme(next);
   }, []);
 
-  const setTheme = useCallback((next: ColorThemeId) => {
-    setThemeState(next);
-    applyColorTheme(next);
-    localStorage.setItem(COLOR_THEME_STORAGE_KEY, next);
+  const setTheme = useCallback(
+    (next: ColorThemeId) => {
+      setThemeState(next);
+      applyColorTheme(next);
+      localStorage.setItem(COLOR_THEME_STORAGE_KEY, next);
+      if (next === "custom") persistCustomTheme(customConfig);
+    },
+    [customConfig],
+  );
+
+  const setCustomConfig = useCallback((config: CustomThemeConfig, options?: { activate?: boolean }) => {
+    const saved = persistCustomTheme(config);
+    setCustomConfigState(saved);
+    if (options?.activate === false) return;
+    setThemeState("custom");
+    applyColorTheme("custom");
+    localStorage.setItem(COLOR_THEME_STORAGE_KEY, "custom");
+  }, []);
+
+  const resetCustomConfig = useCallback(() => {
+    const saved = persistCustomTheme({ primary: DEFAULT_CUSTOM_PRIMARY });
+    setCustomConfigState(saved);
+    setThemeState("custom");
+    applyColorTheme("custom");
+    localStorage.setItem(COLOR_THEME_STORAGE_KEY, "custom");
   }, []);
 
   const value = useMemo<ColorThemeContextValue>(
     () => ({
       theme,
       setTheme,
-      themes: COLOR_THEMES,
-      activeTheme: getColorTheme(theme),
+      themes: getPresetThemes(),
+      activeTheme: getColorTheme(theme, customConfig),
+      customConfig,
+      setCustomConfig,
+      resetCustomConfig,
     }),
-    [theme, setTheme],
+    [theme, setTheme, customConfig, setCustomConfig, resetCustomConfig],
   );
 
   return <ColorThemeContext.Provider value={value}>{children}</ColorThemeContext.Provider>;

--- a/app/color-theme-provider.tsx
+++ b/app/color-theme-provider.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  COLOR_THEME_STORAGE_KEY,
+  COLOR_THEMES,
+  DEFAULT_COLOR_THEME,
+  getColorTheme,
+  isColorThemeId,
+  type ColorThemeId,
+  type ColorThemeMeta,
+} from "@/lib/color-themes";
+
+interface ColorThemeContextValue {
+  theme: ColorThemeId;
+  setTheme: (theme: ColorThemeId) => void;
+  themes: ColorThemeMeta[];
+  activeTheme: ColorThemeMeta;
+}
+
+const ColorThemeContext = createContext<ColorThemeContextValue | null>(null);
+
+function applyColorTheme(theme: ColorThemeId) {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function ColorThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ColorThemeId>(DEFAULT_COLOR_THEME);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(COLOR_THEME_STORAGE_KEY);
+    const next = isColorThemeId(stored) ? stored : DEFAULT_COLOR_THEME;
+    setThemeState(next);
+    applyColorTheme(next);
+  }, []);
+
+  const setTheme = useCallback((next: ColorThemeId) => {
+    setThemeState(next);
+    applyColorTheme(next);
+    localStorage.setItem(COLOR_THEME_STORAGE_KEY, next);
+  }, []);
+
+  const value = useMemo<ColorThemeContextValue>(
+    () => ({
+      theme,
+      setTheme,
+      themes: COLOR_THEMES,
+      activeTheme: getColorTheme(theme),
+    }),
+    [theme, setTheme],
+  );
+
+  return <ColorThemeContext.Provider value={value}>{children}</ColorThemeContext.Provider>;
+}
+
+export function useColorTheme() {
+  const context = useContext(ColorThemeContext);
+  if (!context) {
+    throw new Error("useColorTheme must be used within ColorThemeProvider");
+  }
+  return context;
+}

--- a/app/context-provider.tsx
+++ b/app/context-provider.tsx
@@ -4,26 +4,28 @@ import PHProvider from "./analytics";
 import NextTopLoader from "nextjs-toploader";
 import { TailwindIndicator } from "./tailwind-indicator";
 import { ThemeProvider } from "./theme-provider";
+import { ColorThemeProvider, useColorTheme } from "./color-theme-provider";
 import { SessionProvider } from "next-auth/react";
 import { Toaster } from "@/components/ui/sonner";
-import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { useTheme } from "next-themes";
 
 const TopLoader = () => {
-  const { theme } = useTheme();
+  const { activeTheme } = useColorTheme();
+  const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  return (
-    mounted && (
-      <NextTopLoader showSpinner={false} color={theme === "dark" ? "#fff" : "#000"} height={3} shadow={false} />
-    )
-  );
+  // Zinc dark mode inverts primary to near-white — use a readable loader color.
+  const color =
+    activeTheme.id === "zinc" && resolvedTheme === "dark" ? "#FAFAFA" : activeTheme.loader;
+
+  return mounted && <NextTopLoader showSpinner={false} color={color} height={3} shadow={false} />;
 };
 
 export function ContextProvider({ children }: { children: React.ReactNode }) {
@@ -31,13 +33,15 @@ export function ContextProvider({ children }: { children: React.ReactNode }) {
     <>
       <PHProvider>
         <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
-          <NuqsAdapter>
-            <TopLoader />
-            <TooltipProvider>
-              <SessionProvider>{children}</SessionProvider>
-            </TooltipProvider>
-            <Toaster richColors />
-          </NuqsAdapter>
+          <ColorThemeProvider>
+            <NuqsAdapter>
+              <TopLoader />
+              <TooltipProvider>
+                <SessionProvider>{children}</SessionProvider>
+              </TooltipProvider>
+              <Toaster richColors />
+            </NuqsAdapter>
+          </ColorThemeProvider>
         </ThemeProvider>
       </PHProvider>
       <TailwindIndicator />

--- a/app/globals.css
+++ b/app/globals.css
@@ -186,6 +186,10 @@
 }
 
 @layer base {
+  /*
+    Zinc is the default palette (:root / .dark).
+    Other palettes override via [data-theme="…"] and .dark[data-theme="…"].
+  */
   :root {
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
@@ -212,7 +216,7 @@
     --destructive-foreground: 0 0% 98%;
 
     --success: 161 92% 25%;
-    --success-foreground: 0 0 100%;
+    --success-foreground: 0 0% 100%;
 
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
@@ -261,6 +265,9 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
 
+    --success: 161 70% 40%;
+    --success-foreground: 0 0% 100%;
+
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
@@ -282,6 +289,609 @@
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
   }
+
+  /* —— Brand —— */
+  [data-theme="brand"] {
+    --background: 259 45% 98.5%;
+    --foreground: 258 55% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 258 55% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 258 55% 12%;
+    --primary: 258 65% 28%;
+    --primary-foreground: 259 43% 98%;
+    --secondary: 259 35% 94%;
+    --secondary-foreground: 258 50% 18%;
+    --muted: 259 30% 95%;
+    --muted-foreground: 258 12% 42%;
+    --accent: 259 43% 94%;
+    --accent-foreground: 258 65% 22%;
+    --border: 259 22% 88%;
+    --input: 259 22% 88%;
+    --ring: 333 90% 53%;
+    --chart-1: oklch(0.62 0.24 350);
+    --chart-2: oklch(0.38 0.12 290);
+    --chart-3: oklch(0.86 0.17 110);
+    --chart-4: oklch(0.68 0.15 165);
+    --chart-5: oklch(0.82 0.06 290);
+    --sidebar: oklch(0.98 0.01 290);
+    --sidebar-foreground: oklch(0.22 0.05 290);
+    --sidebar-primary: oklch(0.38 0.12 290);
+    --sidebar-primary-foreground: oklch(0.98 0.01 290);
+    --sidebar-accent: oklch(0.94 0.025 290);
+    --sidebar-accent-foreground: oklch(0.28 0.08 290);
+    --sidebar-border: oklch(0.9 0.02 290);
+    --sidebar-ring: oklch(0.65 0.24 350);
+  }
+
+  .dark[data-theme="brand"] {
+    --background: 258 38% 7%;
+    --foreground: 259 35% 95%;
+    --card: 258 32% 10%;
+    --card-foreground: 259 35% 95%;
+    --popover: 258 32% 10%;
+    --popover-foreground: 259 35% 95%;
+    --primary: 333 85% 58%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 258 25% 16%;
+    --secondary-foreground: 259 35% 95%;
+    --muted: 258 22% 15%;
+    --muted-foreground: 259 12% 68%;
+    --accent: 258 28% 18%;
+    --accent-foreground: 259 43% 94%;
+    --border: 258 20% 18%;
+    --input: 258 20% 18%;
+    --ring: 333 85% 58%;
+    --chart-1: oklch(0.72 0.22 350);
+    --chart-2: oklch(0.78 0.07 290);
+    --chart-3: oklch(0.88 0.16 110);
+    --chart-4: oklch(0.75 0.14 165);
+    --chart-5: oklch(0.58 0.14 290);
+    --sidebar: oklch(0.17 0.04 290);
+    --sidebar-foreground: oklch(0.95 0.01 290);
+    --sidebar-primary: oklch(0.68 0.22 350);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.24 0.04 290);
+    --sidebar-accent-foreground: oklch(0.95 0.01 290);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.68 0.22 350);
+  }
+
+  /* —— Ocean —— */
+  [data-theme="ocean"] {
+    --background: 204 100% 98%;
+    --foreground: 202 80% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 202 80% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 202 80% 12%;
+    --primary: 201 96% 32%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 204 70% 94%;
+    --secondary-foreground: 201 80% 20%;
+    --muted: 204 50% 95%;
+    --muted-foreground: 200 15% 42%;
+    --accent: 199 90% 92%;
+    --accent-foreground: 201 90% 24%;
+    --border: 203 40% 88%;
+    --input: 203 40% 88%;
+    --ring: 199 89% 48%;
+    --chart-1: oklch(0.6 0.15 230);
+    --chart-2: oklch(0.7 0.12 200);
+    --chart-3: oklch(0.55 0.1 250);
+    --chart-4: oklch(0.75 0.1 180);
+    --chart-5: oklch(0.45 0.08 220);
+    --sidebar: oklch(0.98 0.01 230);
+    --sidebar-foreground: oklch(0.22 0.04 230);
+    --sidebar-primary: oklch(0.45 0.12 230);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.02 230);
+    --sidebar-accent-foreground: oklch(0.3 0.06 230);
+    --sidebar-border: oklch(0.9 0.02 230);
+    --sidebar-ring: oklch(0.6 0.14 230);
+  }
+
+  .dark[data-theme="ocean"] {
+    --background: 210 40% 7%;
+    --foreground: 204 40% 96%;
+    --card: 210 35% 10%;
+    --card-foreground: 204 40% 96%;
+    --popover: 210 35% 10%;
+    --popover-foreground: 204 40% 96%;
+    --primary: 199 89% 55%;
+    --primary-foreground: 210 80% 8%;
+    --secondary: 210 30% 16%;
+    --secondary-foreground: 204 40% 96%;
+    --muted: 210 25% 15%;
+    --muted-foreground: 205 15% 68%;
+    --accent: 210 28% 18%;
+    --accent-foreground: 199 80% 85%;
+    --border: 210 22% 18%;
+    --input: 210 22% 18%;
+    --ring: 199 89% 55%;
+    --chart-1: oklch(0.7 0.14 230);
+    --chart-2: oklch(0.75 0.1 200);
+    --chart-3: oklch(0.65 0.1 250);
+    --chart-4: oklch(0.8 0.08 180);
+    --chart-5: oklch(0.55 0.1 220);
+    --sidebar: oklch(0.17 0.03 230);
+    --sidebar-foreground: oklch(0.95 0.01 230);
+    --sidebar-primary: oklch(0.68 0.14 230);
+    --sidebar-primary-foreground: oklch(0.15 0.04 230);
+    --sidebar-accent: oklch(0.24 0.03 230);
+    --sidebar-accent-foreground: oklch(0.95 0.01 230);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.68 0.14 230);
+  }
+
+  /* —— Forest —— */
+  [data-theme="forest"] {
+    --background: 152 50% 98%;
+    --foreground: 160 60% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 160 60% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 160 60% 10%;
+    --primary: 161 94% 20%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 152 40% 93%;
+    --secondary-foreground: 161 70% 16%;
+    --muted: 150 30% 95%;
+    --muted-foreground: 160 12% 40%;
+    --accent: 152 55% 90%;
+    --accent-foreground: 161 80% 18%;
+    --border: 152 25% 86%;
+    --input: 152 25% 86%;
+    --ring: 160 84% 39%;
+    --chart-1: oklch(0.55 0.14 160);
+    --chart-2: oklch(0.7 0.12 145);
+    --chart-3: oklch(0.45 0.1 180);
+    --chart-4: oklch(0.8 0.1 130);
+    --chart-5: oklch(0.4 0.08 155);
+    --sidebar: oklch(0.98 0.015 160);
+    --sidebar-foreground: oklch(0.22 0.04 160);
+    --sidebar-primary: oklch(0.4 0.1 160);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.03 160);
+    --sidebar-accent-foreground: oklch(0.28 0.06 160);
+    --sidebar-border: oklch(0.9 0.02 160);
+    --sidebar-ring: oklch(0.6 0.12 160);
+  }
+
+  .dark[data-theme="forest"] {
+    --background: 160 30% 6%;
+    --foreground: 150 30% 95%;
+    --card: 160 28% 9%;
+    --card-foreground: 150 30% 95%;
+    --popover: 160 28% 9%;
+    --popover-foreground: 150 30% 95%;
+    --primary: 160 84% 45%;
+    --primary-foreground: 160 80% 6%;
+    --secondary: 160 22% 15%;
+    --secondary-foreground: 150 30% 95%;
+    --muted: 160 20% 14%;
+    --muted-foreground: 155 12% 65%;
+    --accent: 160 24% 17%;
+    --accent-foreground: 152 60% 80%;
+    --border: 160 18% 17%;
+    --input: 160 18% 17%;
+    --ring: 160 84% 45%;
+    --chart-1: oklch(0.7 0.14 160);
+    --chart-2: oklch(0.75 0.1 145);
+    --chart-3: oklch(0.6 0.1 180);
+    --chart-4: oklch(0.82 0.1 130);
+    --chart-5: oklch(0.55 0.08 155);
+    --sidebar: oklch(0.16 0.03 160);
+    --sidebar-foreground: oklch(0.95 0.01 160);
+    --sidebar-primary: oklch(0.7 0.14 160);
+    --sidebar-primary-foreground: oklch(0.15 0.04 160);
+    --sidebar-accent: oklch(0.23 0.03 160);
+    --sidebar-accent-foreground: oklch(0.95 0.01 160);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.7 0.14 160);
+  }
+
+  /* —— Sunset —— */
+  [data-theme="sunset"] {
+    --background: 30 100% 98%;
+    --foreground: 20 60% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 20 60% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 20 60% 12%;
+    --primary: 21 90% 32%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 30 80% 94%;
+    --secondary-foreground: 21 70% 22%;
+    --muted: 30 50% 95%;
+    --muted-foreground: 20 12% 42%;
+    --accent: 27 90% 90%;
+    --accent-foreground: 21 80% 24%;
+    --border: 28 40% 88%;
+    --input: 28 40% 88%;
+    --ring: 25 95% 53%;
+    --chart-1: oklch(0.65 0.18 50);
+    --chart-2: oklch(0.7 0.15 30);
+    --chart-3: oklch(0.75 0.14 70);
+    --chart-4: oklch(0.55 0.16 20);
+    --chart-5: oklch(0.8 0.1 85);
+    --sidebar: oklch(0.98 0.015 50);
+    --sidebar-foreground: oklch(0.22 0.04 40);
+    --sidebar-primary: oklch(0.5 0.14 40);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.03 50);
+    --sidebar-accent-foreground: oklch(0.3 0.08 40);
+    --sidebar-border: oklch(0.9 0.02 50);
+    --sidebar-ring: oklch(0.65 0.16 50);
+  }
+
+  .dark[data-theme="sunset"] {
+    --background: 20 35% 7%;
+    --foreground: 30 40% 96%;
+    --card: 20 30% 10%;
+    --card-foreground: 30 40% 96%;
+    --popover: 20 30% 10%;
+    --popover-foreground: 30 40% 96%;
+    --primary: 25 95% 55%;
+    --primary-foreground: 20 80% 8%;
+    --secondary: 20 25% 16%;
+    --secondary-foreground: 30 40% 96%;
+    --muted: 20 22% 15%;
+    --muted-foreground: 25 12% 68%;
+    --accent: 20 26% 18%;
+    --accent-foreground: 30 80% 80%;
+    --border: 20 20% 18%;
+    --input: 20 20% 18%;
+    --ring: 25 95% 55%;
+    --chart-1: oklch(0.72 0.16 50);
+    --chart-2: oklch(0.75 0.14 30);
+    --chart-3: oklch(0.8 0.12 70);
+    --chart-4: oklch(0.65 0.14 20);
+    --chart-5: oklch(0.85 0.1 85);
+    --sidebar: oklch(0.16 0.03 40);
+    --sidebar-foreground: oklch(0.95 0.01 50);
+    --sidebar-primary: oklch(0.7 0.16 50);
+    --sidebar-primary-foreground: oklch(0.15 0.04 40);
+    --sidebar-accent: oklch(0.24 0.03 40);
+    --sidebar-accent-foreground: oklch(0.95 0.01 50);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.7 0.16 50);
+  }
+
+  /* —— Rose —— */
+  [data-theme="rose"] {
+    --background: 350 100% 98.5%;
+    --foreground: 345 60% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 345 60% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 345 60% 12%;
+    --primary: 345 80% 30%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 350 60% 94%;
+    --secondary-foreground: 345 70% 22%;
+    --muted: 350 40% 95%;
+    --muted-foreground: 345 12% 42%;
+    --accent: 350 80% 92%;
+    --accent-foreground: 345 75% 24%;
+    --border: 350 30% 88%;
+    --input: 350 30% 88%;
+    --ring: 347 77% 50%;
+    --chart-1: oklch(0.6 0.2 15);
+    --chart-2: oklch(0.7 0.15 350);
+    --chart-3: oklch(0.55 0.14 30);
+    --chart-4: oklch(0.75 0.1 340);
+    --chart-5: oklch(0.45 0.12 10);
+    --sidebar: oklch(0.98 0.01 15);
+    --sidebar-foreground: oklch(0.22 0.05 15);
+    --sidebar-primary: oklch(0.45 0.15 15);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.03 15);
+    --sidebar-accent-foreground: oklch(0.3 0.08 15);
+    --sidebar-border: oklch(0.9 0.02 15);
+    --sidebar-ring: oklch(0.65 0.18 15);
+  }
+
+  .dark[data-theme="rose"] {
+    --background: 345 35% 7%;
+    --foreground: 350 35% 96%;
+    --card: 345 30% 10%;
+    --card-foreground: 350 35% 96%;
+    --popover: 345 30% 10%;
+    --popover-foreground: 350 35% 96%;
+    --primary: 347 77% 58%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 345 25% 16%;
+    --secondary-foreground: 350 35% 96%;
+    --muted: 345 22% 15%;
+    --muted-foreground: 350 12% 68%;
+    --accent: 345 26% 18%;
+    --accent-foreground: 350 70% 85%;
+    --border: 345 20% 18%;
+    --input: 345 20% 18%;
+    --ring: 347 77% 58%;
+    --chart-1: oklch(0.7 0.18 15);
+    --chart-2: oklch(0.75 0.12 350);
+    --chart-3: oklch(0.65 0.12 30);
+    --chart-4: oklch(0.8 0.08 340);
+    --chart-5: oklch(0.55 0.12 10);
+    --sidebar: oklch(0.16 0.03 15);
+    --sidebar-foreground: oklch(0.95 0.01 15);
+    --sidebar-primary: oklch(0.68 0.18 15);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.24 0.03 15);
+    --sidebar-accent-foreground: oklch(0.95 0.01 15);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.68 0.18 15);
+  }
+
+  /* —— Violet —— */
+  [data-theme="violet"] {
+    --background: 270 60% 98.5%;
+    --foreground: 270 50% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 270 50% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 270 50% 12%;
+    --primary: 263 70% 35%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 270 45% 94%;
+    --secondary-foreground: 263 55% 24%;
+    --muted: 270 30% 95%;
+    --muted-foreground: 270 12% 42%;
+    --accent: 270 60% 92%;
+    --accent-foreground: 263 65% 28%;
+    --border: 270 25% 88%;
+    --input: 270 25% 88%;
+    --ring: 262 83% 58%;
+    --chart-1: oklch(0.55 0.2 290);
+    --chart-2: oklch(0.65 0.16 310);
+    --chart-3: oklch(0.5 0.14 270);
+    --chart-4: oklch(0.75 0.1 300);
+    --chart-5: oklch(0.45 0.12 280);
+    --sidebar: oklch(0.98 0.01 290);
+    --sidebar-foreground: oklch(0.22 0.05 290);
+    --sidebar-primary: oklch(0.45 0.16 290);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.03 290);
+    --sidebar-accent-foreground: oklch(0.3 0.08 290);
+    --sidebar-border: oklch(0.9 0.02 290);
+    --sidebar-ring: oklch(0.65 0.18 290);
+  }
+
+  .dark[data-theme="violet"] {
+    --background: 270 35% 7%;
+    --foreground: 270 30% 96%;
+    --card: 270 30% 10%;
+    --card-foreground: 270 30% 96%;
+    --popover: 270 30% 10%;
+    --popover-foreground: 270 30% 96%;
+    --primary: 263 70% 65%;
+    --primary-foreground: 270 60% 8%;
+    --secondary: 270 25% 16%;
+    --secondary-foreground: 270 30% 96%;
+    --muted: 270 22% 15%;
+    --muted-foreground: 270 12% 68%;
+    --accent: 270 26% 18%;
+    --accent-foreground: 270 60% 85%;
+    --border: 270 20% 18%;
+    --input: 270 20% 18%;
+    --ring: 263 70% 65%;
+    --chart-1: oklch(0.7 0.18 290);
+    --chart-2: oklch(0.75 0.12 310);
+    --chart-3: oklch(0.6 0.12 270);
+    --chart-4: oklch(0.8 0.08 300);
+    --chart-5: oklch(0.55 0.12 280);
+    --sidebar: oklch(0.16 0.03 290);
+    --sidebar-foreground: oklch(0.95 0.01 290);
+    --sidebar-primary: oklch(0.7 0.16 290);
+    --sidebar-primary-foreground: oklch(0.15 0.04 290);
+    --sidebar-accent: oklch(0.24 0.03 290);
+    --sidebar-accent-foreground: oklch(0.95 0.01 290);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.7 0.16 290);
+  }
+
+  /* —— Teal —— */
+  [data-theme="teal"] {
+    --background: 175 50% 98%;
+    --foreground: 175 55% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 175 55% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 175 55% 10%;
+    --primary: 175 77% 22%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 175 40% 93%;
+    --secondary-foreground: 175 60% 18%;
+    --muted: 175 30% 95%;
+    --muted-foreground: 175 12% 40%;
+    --accent: 172 55% 90%;
+    --accent-foreground: 175 70% 18%;
+    --border: 175 25% 86%;
+    --input: 175 25% 86%;
+    --ring: 173 80% 36%;
+    --chart-1: oklch(0.55 0.12 180);
+    --chart-2: oklch(0.7 0.1 195);
+    --chart-3: oklch(0.5 0.1 165);
+    --chart-4: oklch(0.75 0.08 200);
+    --chart-5: oklch(0.45 0.08 175);
+    --sidebar: oklch(0.98 0.015 180);
+    --sidebar-foreground: oklch(0.22 0.04 180);
+    --sidebar-primary: oklch(0.42 0.1 180);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.03 180);
+    --sidebar-accent-foreground: oklch(0.28 0.06 180);
+    --sidebar-border: oklch(0.9 0.02 180);
+    --sidebar-ring: oklch(0.6 0.1 180);
+  }
+
+  .dark[data-theme="teal"] {
+    --background: 180 30% 6%;
+    --foreground: 175 30% 95%;
+    --card: 180 28% 9%;
+    --card-foreground: 175 30% 95%;
+    --popover: 180 28% 9%;
+    --popover-foreground: 175 30% 95%;
+    --primary: 173 70% 45%;
+    --primary-foreground: 180 80% 6%;
+    --secondary: 180 22% 15%;
+    --secondary-foreground: 175 30% 95%;
+    --muted: 180 20% 14%;
+    --muted-foreground: 175 12% 65%;
+    --accent: 180 24% 17%;
+    --accent-foreground: 172 50% 80%;
+    --border: 180 18% 17%;
+    --input: 180 18% 17%;
+    --ring: 173 70% 45%;
+    --chart-1: oklch(0.7 0.12 180);
+    --chart-2: oklch(0.75 0.1 195);
+    --chart-3: oklch(0.6 0.1 165);
+    --chart-4: oklch(0.8 0.08 200);
+    --chart-5: oklch(0.55 0.08 175);
+    --sidebar: oklch(0.16 0.03 180);
+    --sidebar-foreground: oklch(0.95 0.01 180);
+    --sidebar-primary: oklch(0.7 0.12 180);
+    --sidebar-primary-foreground: oklch(0.15 0.04 180);
+    --sidebar-accent: oklch(0.23 0.03 180);
+    --sidebar-accent-foreground: oklch(0.95 0.01 180);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.7 0.12 180);
+  }
+
+  /* —— Amber —— */
+  [data-theme="amber"] {
+    --background: 48 100% 97%;
+    --foreground: 32 50% 12%;
+    --card: 0 0% 100%;
+    --card-foreground: 32 50% 12%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 32 50% 12%;
+    --primary: 32 95% 28%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 45 80% 92%;
+    --secondary-foreground: 32 70% 20%;
+    --muted: 45 50% 94%;
+    --muted-foreground: 32 12% 40%;
+    --accent: 45 90% 88%;
+    --accent-foreground: 32 80% 22%;
+    --border: 43 40% 86%;
+    --input: 43 40% 86%;
+    --ring: 38 92% 50%;
+    --chart-1: oklch(0.75 0.15 85);
+    --chart-2: oklch(0.7 0.14 60);
+    --chart-3: oklch(0.65 0.12 100);
+    --chart-4: oklch(0.55 0.12 45);
+    --chart-5: oklch(0.8 0.1 95);
+    --sidebar: oklch(0.98 0.02 85);
+    --sidebar-foreground: oklch(0.22 0.04 60);
+    --sidebar-primary: oklch(0.5 0.12 70);
+    --sidebar-primary-foreground: oklch(0.99 0 0);
+    --sidebar-accent: oklch(0.94 0.04 85);
+    --sidebar-accent-foreground: oklch(0.3 0.06 60);
+    --sidebar-border: oklch(0.9 0.03 85);
+    --sidebar-ring: oklch(0.7 0.14 85);
+  }
+
+  .dark[data-theme="amber"] {
+    --background: 30 30% 7%;
+    --foreground: 45 40% 95%;
+    --card: 30 28% 10%;
+    --card-foreground: 45 40% 95%;
+    --popover: 30 28% 10%;
+    --popover-foreground: 45 40% 95%;
+    --primary: 38 92% 55%;
+    --primary-foreground: 30 80% 8%;
+    --secondary: 30 22% 16%;
+    --secondary-foreground: 45 40% 95%;
+    --muted: 30 20% 14%;
+    --muted-foreground: 40 12% 65%;
+    --accent: 30 24% 17%;
+    --accent-foreground: 45 70% 80%;
+    --border: 30 18% 17%;
+    --input: 30 18% 17%;
+    --ring: 38 92% 55%;
+    --chart-1: oklch(0.8 0.14 85);
+    --chart-2: oklch(0.75 0.12 60);
+    --chart-3: oklch(0.7 0.1 100);
+    --chart-4: oklch(0.65 0.12 45);
+    --chart-5: oklch(0.85 0.1 95);
+    --sidebar: oklch(0.16 0.03 60);
+    --sidebar-foreground: oklch(0.95 0.01 85);
+    --sidebar-primary: oklch(0.75 0.14 85);
+    --sidebar-primary-foreground: oklch(0.15 0.04 60);
+    --sidebar-accent: oklch(0.23 0.03 60);
+    --sidebar-accent-foreground: oklch(0.95 0.01 85);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.75 0.14 85);
+  }
+
+  /* —— Slate —— */
+  [data-theme="slate"] {
+    --background: 210 40% 98%;
+    --foreground: 222 47% 11%;
+    --card: 0 0% 100%;
+    --card-foreground: 222 47% 11%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 215 28% 17%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 214 32% 93%;
+    --secondary-foreground: 215 28% 17%;
+    --muted: 210 30% 95%;
+    --muted-foreground: 215 16% 42%;
+    --accent: 214 32% 91%;
+    --accent-foreground: 215 28% 17%;
+    --border: 214 25% 88%;
+    --input: 214 25% 88%;
+    --ring: 215 20% 40%;
+    --chart-1: oklch(0.55 0.06 250);
+    --chart-2: oklch(0.65 0.05 230);
+    --chart-3: oklch(0.45 0.05 250);
+    --chart-4: oklch(0.75 0.04 220);
+    --chart-5: oklch(0.4 0.04 240);
+    --sidebar: oklch(0.98 0.005 250);
+    --sidebar-foreground: oklch(0.22 0.02 250);
+    --sidebar-primary: oklch(0.35 0.04 250);
+    --sidebar-primary-foreground: oklch(0.98 0.005 250);
+    --sidebar-accent: oklch(0.94 0.01 250);
+    --sidebar-accent-foreground: oklch(0.28 0.03 250);
+    --sidebar-border: oklch(0.9 0.01 250);
+    --sidebar-ring: oklch(0.55 0.04 250);
+  }
+
+  .dark[data-theme="slate"] {
+    --background: 222 47% 7%;
+    --foreground: 210 40% 96%;
+    --card: 222 40% 10%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 40% 10%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 210 40% 96%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 217 25% 16%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 217 22% 15%;
+    --muted-foreground: 215 15% 65%;
+    --accent: 217 25% 17%;
+    --accent-foreground: 210 40% 96%;
+    --border: 217 20% 18%;
+    --input: 217 20% 18%;
+    --ring: 215 20% 65%;
+    --chart-1: oklch(0.7 0.05 250);
+    --chart-2: oklch(0.65 0.04 230);
+    --chart-3: oklch(0.55 0.04 250);
+    --chart-4: oklch(0.75 0.03 220);
+    --chart-5: oklch(0.5 0.04 240);
+    --sidebar: oklch(0.18 0.02 250);
+    --sidebar-foreground: oklch(0.95 0.005 250);
+    --sidebar-primary: oklch(0.65 0.05 250);
+    --sidebar-primary-foreground: oklch(0.18 0.02 250);
+    --sidebar-accent: oklch(0.25 0.02 250);
+    --sidebar-accent-foreground: oklch(0.95 0.005 250);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.55 0.03 250);
+  }
 }
 
 @layer utilities {
@@ -291,7 +901,7 @@
     height: 42px;
     top: -30px;
     left: -20.5px;
-    @apply absolute border border-gray-200;
+    @apply absolute border-border border;
     border-bottom-left-radius: 6px;
     border-right: transparent;
     border-top: transparent;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { siteConfig } from "@/config/site";
 import { fontVariables } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { COLOR_THEME_IDS, COLOR_THEME_STORAGE_KEY, DEFAULT_COLOR_THEME } from "@/lib/color-themes";
+import { CUSTOM_THEME_STORAGE_KEY, CUSTOM_THEME_STYLE_ID } from "@/lib/generate-theme";
 import { ContextProvider } from "./context-provider";
 import { SiteHeader } from "./site-header";
 import { getAllProjects } from "@/server/services/project";
@@ -41,7 +42,7 @@ export const viewport: Viewport = {
   ],
 };
 
-const colorThemeInitScript = `(function(){try{var t=localStorage.getItem(${JSON.stringify(COLOR_THEME_STORAGE_KEY)});var v=${JSON.stringify([...COLOR_THEME_IDS])};document.documentElement.dataset.theme=v.indexOf(t)>=0?t:${JSON.stringify(DEFAULT_COLOR_THEME)};}catch(e){document.documentElement.dataset.theme=${JSON.stringify(DEFAULT_COLOR_THEME)};}})();`;
+const colorThemeInitScript = `(function(){try{var t=localStorage.getItem(${JSON.stringify(COLOR_THEME_STORAGE_KEY)});var v=${JSON.stringify([...COLOR_THEME_IDS])};var theme=v.indexOf(t)>=0?t:${JSON.stringify(DEFAULT_COLOR_THEME)};document.documentElement.dataset.theme=theme;if(theme==="custom"){var css=localStorage.getItem(${JSON.stringify(`${CUSTOM_THEME_STORAGE_KEY}-css`)});if(css){var s=document.getElementById(${JSON.stringify(CUSTOM_THEME_STYLE_ID)});if(!s){s=document.createElement("style");s.id=${JSON.stringify(CUSTOM_THEME_STYLE_ID)};document.head.appendChild(s);}s.textContent=css;}}}catch(e){document.documentElement.dataset.theme=${JSON.stringify(DEFAULT_COLOR_THEME)};}})();`;
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata, Viewport } from "next";
 import { siteConfig } from "@/config/site";
 import { fontVariables } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
+import { COLOR_THEME_IDS, COLOR_THEME_STORAGE_KEY, DEFAULT_COLOR_THEME } from "@/lib/color-themes";
 import { ContextProvider } from "./context-provider";
 import { SiteHeader } from "./site-header";
 import { getAllProjects } from "@/server/services/project";
@@ -40,6 +41,8 @@ export const viewport: Viewport = {
   ],
 };
 
+const colorThemeInitScript = `(function(){try{var t=localStorage.getItem(${JSON.stringify(COLOR_THEME_STORAGE_KEY)});var v=${JSON.stringify([...COLOR_THEME_IDS])};document.documentElement.dataset.theme=v.indexOf(t)>=0?t:${JSON.stringify(DEFAULT_COLOR_THEME)};}catch(e){document.documentElement.dataset.theme=${JSON.stringify(DEFAULT_COLOR_THEME)};}})();`;
+
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
 
@@ -49,6 +52,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+        <script dangerouslySetInnerHTML={{ __html: colorThemeInitScript }} />
       </head>
       <body
         className={cn(

--- a/app/manage/appearance.tsx
+++ b/app/manage/appearance.tsx
@@ -6,12 +6,15 @@ import { Check, Moon, Sun } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useColorTheme } from "@/app/color-theme-provider";
+import { CustomThemePicker } from "@/app/manage/custom-theme-picker";
+import { getCustomThemeMeta } from "@/lib/color-themes";
 import { cn } from "@/lib/utils";
 
 export function Appearance() {
   const { theme: mode, setTheme: setMode } = useTheme();
-  const { theme: colorTheme, setTheme: setColorTheme, themes } = useColorTheme();
+  const { theme: colorTheme, setTheme: setColorTheme, themes, customConfig } = useColorTheme();
   const [mounted, setMounted] = useState(false);
+  const customMeta = getCustomThemeMeta(customConfig);
 
   useEffect(() => setMounted(true), []);
 
@@ -54,7 +57,7 @@ export function Appearance() {
           </p>
         </div>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {themes.map((item) => {
+          {[...themes, customMeta].map((item) => {
             const isActive = colorTheme === item.id;
             return (
               <button
@@ -84,7 +87,7 @@ export function Appearance() {
                     <span className="flex gap-0.5">
                       {item.swatches.slice(0, 3).map((swatch) => (
                         <span
-                          key={swatch}
+                          key={`${item.id}-${swatch}`}
                           className="border-border size-2.5 rounded-full border"
                           style={{ backgroundColor: swatch }}
                         />
@@ -98,6 +101,8 @@ export function Appearance() {
           })}
         </div>
       </section>
+
+      <CustomThemePicker />
     </div>
   );
 }

--- a/app/manage/appearance.tsx
+++ b/app/manage/appearance.tsx
@@ -2,41 +2,102 @@
 
 import { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
-import { Moon, Sun } from "lucide-react";
+import { Check, Moon, Sun } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useColorTheme } from "@/app/color-theme-provider";
 import { cn } from "@/lib/utils";
 
 export function Appearance() {
-  const { theme, setTheme } = useTheme();
+  const { theme: mode, setTheme: setMode } = useTheme();
+  const { theme: colorTheme, setTheme: setColorTheme, themes } = useColorTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
 
+  if (!mounted) return null;
+
   return (
-    mounted && (
-      <div className="mt-1 space-y-6">
+    <div className="mt-1 space-y-8">
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Mode</h3>
+          <p className="text-muted-foreground text-sm">Switch between light and dark appearance.</p>
+        </div>
         <div className="flex gap-2">
           <Button
             size="sm"
             variant="outline"
-            className={cn("flex w-32 items-center gap-2", theme === "light" && "border-primary")}
-            onClick={() => setTheme("light")}
+            className={cn("flex w-32 items-center gap-2", mode === "light" && "border-primary ring-ring ring-1")}
+            onClick={() => setMode("light")}
           >
-            <Sun size={18} />
+            <Sun size={16} />
             Light
           </Button>
           <Button
             size="sm"
             variant="outline"
-            className={cn("flex w-32 items-center gap-2", theme === "dark" && "border-primary")}
-            onClick={() => setTheme("dark")}
+            className={cn("flex w-32 items-center gap-2", mode === "dark" && "border-primary ring-ring ring-1")}
+            onClick={() => setMode("dark")}
           >
-            <Moon size={18} />
+            <Moon size={16} />
             Dark
           </Button>
         </div>
-      </div>
-    )
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Color theme</h3>
+          <p className="text-muted-foreground text-sm">
+            Choose a palette. Zinc is the original neutral look. Works with both light and dark mode.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+          {themes.map((item) => {
+            const isActive = colorTheme === item.id;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setColorTheme(item.id)}
+                aria-pressed={isActive}
+                className={cn(
+                  "border-border bg-card hover:border-primary/40 relative flex flex-col gap-2.5 rounded-lg border p-3 text-left transition-colors",
+                  isActive && "border-primary ring-ring ring-1",
+                )}
+              >
+                {isActive && (
+                  <span className="bg-primary text-primary-foreground absolute top-2 right-2 flex size-5 items-center justify-center rounded-full">
+                    <Check size={12} strokeWidth={3} />
+                  </span>
+                )}
+                <div
+                  className="border-border h-12 w-full overflow-hidden rounded-md border"
+                  style={{
+                    background: `linear-gradient(135deg, ${item.swatches[3]} 0%, ${item.swatches[2]} 45%, ${item.swatches[1]} 75%, ${item.swatches[0]} 100%)`,
+                  }}
+                />
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between gap-1">
+                    <span className="text-sm font-medium">{item.name}</span>
+                    <span className="flex gap-0.5">
+                      {item.swatches.slice(0, 3).map((swatch) => (
+                        <span
+                          key={swatch}
+                          className="border-border size-2.5 rounded-full border"
+                          style={{ backgroundColor: swatch }}
+                        />
+                      ))}
+                    </span>
+                  </div>
+                  <p className="text-muted-foreground line-clamp-2 text-[11px] leading-snug">{item.description}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/app/manage/custom-theme-picker.tsx
+++ b/app/manage/custom-theme-picker.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Pipette, RotateCcw } from "lucide-react";
+
+import { useColorTheme } from "@/app/color-theme-provider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { generateThemeFromPrimary, normalizeHex } from "@/lib/generate-theme";
+import { cn } from "@/lib/utils";
+
+const PRESET_SEEDS = ["#7C3AED", "#F31B7C", "#0284C7", "#059669", "#EA580C", "#E11D48", "#0D9488", "#D97706"];
+
+export function CustomThemePicker() {
+  const { theme, customConfig, setCustomConfig, resetCustomConfig } = useColorTheme();
+  const [primaryDraft, setPrimaryDraft] = useState(customConfig.primary);
+  const [accentDraft, setAccentDraft] = useState(customConfig.accent ?? "");
+  const [useAccent, setUseAccent] = useState(Boolean(customConfig.accent));
+
+  useEffect(() => {
+    setPrimaryDraft(customConfig.primary);
+    setAccentDraft(customConfig.accent ?? "");
+    setUseAccent(Boolean(customConfig.accent));
+  }, [customConfig]);
+
+  const primaryHex = normalizeHex(primaryDraft) ?? customConfig.primary;
+  const accentHex = useAccent ? normalizeHex(accentDraft) ?? undefined : undefined;
+  const preview = useMemo(() => generateThemeFromPrimary(primaryHex, accentHex), [primaryHex, accentHex]);
+  const isActive = theme === "custom";
+
+  function apply(nextPrimary = primaryHex, nextAccent = accentHex) {
+    setCustomConfig({
+      primary: nextPrimary,
+      ...(nextAccent ? { accent: nextAccent } : {}),
+    });
+  }
+
+  function handlePrimaryColorInput(value: string) {
+    setPrimaryDraft(value.toUpperCase());
+    apply(value.toUpperCase(), accentHex);
+  }
+
+  function handleAccentColorInput(value: string) {
+    setAccentDraft(value.toUpperCase());
+    if (useAccent) apply(primaryHex, value.toUpperCase());
+  }
+
+  function handlePrimaryHexBlur() {
+    const normalized = normalizeHex(primaryDraft);
+    if (!normalized) {
+      setPrimaryDraft(customConfig.primary);
+      return;
+    }
+    setPrimaryDraft(normalized);
+    apply(normalized, accentHex);
+  }
+
+  function handleAccentHexBlur() {
+    if (!useAccent) return;
+    const normalized = normalizeHex(accentDraft);
+    if (!normalized) {
+      setAccentDraft(customConfig.accent ?? "");
+      return;
+    }
+    setAccentDraft(normalized);
+    apply(primaryHex, normalized);
+  }
+
+  return (
+    <section
+      className={cn(
+        "border-border bg-card space-y-4 rounded-lg border p-4",
+        isActive && "border-primary ring-ring ring-1",
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="flex items-center gap-2 text-sm font-medium">
+            <Pipette size={16} />
+            Custom theme
+          </h3>
+          <p className="text-muted-foreground text-sm">
+            Pick a primary color (and optional accent). We generate light and dark tokens so you can experiment live.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button type="button" size="sm" variant="outline" onClick={() => resetCustomConfig()}>
+            <RotateCcw size={14} />
+            Reset
+          </Button>
+          <Button type="button" size="sm" variant={isActive ? "default" : "secondary"} onClick={() => apply()}>
+            {isActive ? "Applied" : "Apply custom"}
+          </Button>
+        </div>
+      </div>
+
+      <div
+        className="border-border h-16 w-full overflow-hidden rounded-md border"
+        style={{
+          background: `linear-gradient(135deg, ${preview.swatches[3]} 0%, ${preview.swatches[2]} 40%, ${preview.swatches[1]} 70%, ${preview.swatches[0]} 100%)`,
+        }}
+      />
+
+      <div className="flex flex-wrap gap-1.5">
+        {preview.swatches.map((swatch) => (
+          <span
+            key={swatch}
+            className="border-border size-7 rounded-md border shadow-xs"
+            style={{ backgroundColor: swatch }}
+            title={swatch}
+          />
+        ))}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="custom-primary">Primary</Label>
+          <div className="flex items-center gap-2">
+            <input
+              id="custom-primary-swatch"
+              type="color"
+              value={primaryHex}
+              onChange={(event) => handlePrimaryColorInput(event.target.value)}
+              className="border-border h-9 w-12 cursor-pointer rounded-md border bg-transparent p-1"
+              aria-label="Primary color picker"
+            />
+            <Input
+              id="custom-primary"
+              value={primaryDraft}
+              onChange={(event) => setPrimaryDraft(event.target.value)}
+              onBlur={handlePrimaryHexBlur}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") handlePrimaryHexBlur();
+              }}
+              spellCheck={false}
+              className="font-mono uppercase"
+              placeholder="#7C3AED"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="custom-accent">Accent (optional)</Label>
+            <label className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <input
+                type="checkbox"
+                checked={useAccent}
+                onChange={(event) => {
+                  const enabled = event.target.checked;
+                  setUseAccent(enabled);
+                  if (!enabled) {
+                    apply(primaryHex, undefined);
+                    setAccentDraft("");
+                  } else {
+                    const seed = normalizeHex(accentDraft) ?? primaryHex;
+                    setAccentDraft(seed);
+                    apply(primaryHex, seed);
+                  }
+                }}
+              />
+              Use accent
+            </label>
+          </div>
+          <div className={cn("flex items-center gap-2", !useAccent && "opacity-50")}>
+            <input
+              id="custom-accent-swatch"
+              type="color"
+              value={normalizeHex(accentDraft) ?? primaryHex}
+              disabled={!useAccent}
+              onChange={(event) => handleAccentColorInput(event.target.value)}
+              className="border-border h-9 w-12 cursor-pointer rounded-md border bg-transparent p-1 disabled:cursor-not-allowed"
+              aria-label="Accent color picker"
+            />
+            <Input
+              id="custom-accent"
+              value={accentDraft}
+              disabled={!useAccent}
+              onChange={(event) => setAccentDraft(event.target.value)}
+              onBlur={handleAccentHexBlur}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") handleAccentHexBlur();
+              }}
+              spellCheck={false}
+              className="font-mono uppercase"
+              placeholder="#F31B7C"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">Quick seeds</p>
+        <div className="flex flex-wrap gap-2">
+          {PRESET_SEEDS.map((seed) => (
+            <button
+              key={seed}
+              type="button"
+              title={seed}
+              onClick={() => {
+                setPrimaryDraft(seed);
+                apply(seed, accentHex);
+              }}
+              className={cn(
+                "border-border size-8 rounded-full border transition-transform hover:scale-110",
+                primaryHex === seed && "ring-ring ring-2 ring-offset-2 ring-offset-background",
+              )}
+              style={{ backgroundColor: seed }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="bg-muted/60 grid grid-cols-2 gap-2 rounded-md p-3 sm:grid-cols-4">
+        {[
+          { label: "Primary", className: "bg-primary" },
+          { label: "Accent", className: "bg-accent border border-border" },
+          { label: "Muted", className: "bg-muted border border-border" },
+          { label: "Card", className: "bg-card border border-border" },
+        ].map((item) => (
+          <div key={item.label} className="space-y-1.5">
+            <div className={cn("h-8 rounded-md", item.className)} />
+            <p className="text-muted-foreground text-[11px]">{item.label}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/mobile-menu.tsx
+++ b/app/mobile-menu.tsx
@@ -149,10 +149,10 @@ export function MobileNavMenu({ userProps, role }: { userProps: UserPropsInterfa
         {/* Avatar area */}
         {status === "authenticated" && (
           <div className="absolute bottom-0 left-0 flex w-full items-center border-t px-3 py-2">
-            <UserAvatar user={{ name: name ?? null, image: image ?? null }} className="h-10 w-10 bg-slate-300" />
+            <UserAvatar user={{ name: name ?? null, image: image ?? null }} className="bg-secondary h-10 w-10" />
             <div className="ml-2">
               <p className="font-medium">{name}</p>
-              <p className="w-[200px] truncate text-sm text-zinc-600 dark:text-zinc-100">{email}</p>
+              <p className="text-muted-foreground w-[200px] truncate text-sm">{email}</p>
             </div>
             {/* CTAs */}
             <div className="ml-auto flex gap-2">

--- a/app/site-header.tsx
+++ b/app/site-header.tsx
@@ -38,7 +38,7 @@ export function SiteHeader({ projects }: { projects?: Project[] }) {
   const isAuthPage = pathname.includes("/auth/");
 
   return (
-    <header className="sticky top-0 z-50 mb-4 w-full border-b bg-background/95 backdrop-blur-sm supports-backdrop-filter:bg-background/60 print:hidden">
+    <header className="bg-background/95 sticky top-0 z-50 mb-4 w-full border-b backdrop-blur-sm supports-backdrop-filter:bg-background/60 print:hidden">
       <div className="container flex h-14 items-center space-x-4">
         {/* Site Logo/Title */}
         <Link href={slug ? `/${slug}` : "/"} aria-label={siteConfig.name}>

--- a/app/theme-toggle.tsx
+++ b/app/theme-toggle.tsx
@@ -19,8 +19,8 @@ export function ThemeToggle({ className }: { className?: string }) {
 
   return (
     <Button size="icon" variant="outline" aria-label="Toggle theme" onClick={handleToggle} className={className}>
-      <SunMedium className="rotate-0 scale-100 transition-all hover:text-zinc-950 dark:-rotate-90 dark:scale-0 dark:text-zinc-400 dark:hover:text-zinc-100" />
-      <Moon className="absolute rotate-90 scale-0 transition-all hover:text-zinc-950 dark:rotate-0 dark:scale-100 dark:text-zinc-400 dark:hover:text-zinc-100" />
+      <SunMedium className="rotate-0 scale-100 transition-all hover:text-foreground dark:-rotate-90 dark:scale-0 dark:text-muted-foreground dark:hover:text-foreground" />
+      <Moon className="absolute rotate-90 scale-0 transition-all hover:text-foreground dark:rotate-0 dark:scale-100 dark:text-muted-foreground dark:hover:text-foreground" />
     </Button>
   );
 }

--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "css": "app/globals.css",
-    "baseColor": "zinc",
+    "baseColor": "violet",
     "cssVariables": true
   },
   "iconLibrary": "lucide",

--- a/components/ai/notepad-cards.tsx
+++ b/components/ai/notepad-cards.tsx
@@ -218,7 +218,7 @@ const NotepadCards = ({
                   }
                   className={cn(
                     selectedData.billable && "text-success hover:text-success",
-                    !selectedData.billable && "text-slate-400 hover:text-slate-400",
+                    !selectedData.billable && "text-muted-foreground hover:text-muted-foreground",
                   )}
                 >
                   <CircleDollarSign size={20} />

--- a/components/charts/donut-chart.tsx
+++ b/components/charts/donut-chart.tsx
@@ -19,6 +19,11 @@ const COLOR_MAP: Record<string, string> = {
   slate: "#94a3b8",
   zinc: "#71717a",
   emerald: "#10b981",
+  fuchsia: "#F31B7C",
+  eggplant: "#201547",
+  lilac: "#C4B5E0",
+  citron: "#C5D92C",
+  violet: "#7C3AED",
 };
 
 function resolveColor(color: string): string {

--- a/components/command-action.tsx
+++ b/components/command-action.tsx
@@ -121,11 +121,11 @@ export function CommandMenu(CommandProps: CommandPropType) {
             >
               <SunMedium
                 size="16"
-                className="mr-2 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 dark:text-zinc-400"
+                className="mr-2 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 dark:text-muted-foreground"
               />
               <Moon
                 size="16"
-                className="absolute mr-2 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100 dark:text-zinc-400"
+                className="text-muted-foreground absolute mr-2 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
               />
               <span>Switch Light/Dark color mode</span>
               <CommandShortcut>Action</CommandShortcut>

--- a/components/forms/timelog-board.tsx
+++ b/components/forms/timelog-board.tsx
@@ -533,7 +533,7 @@ export const TimeLogBoard = ({
                       "shrink-0",
                       selectedData.billable
                         ? "border-success bg-success text-white hover:bg-success hover:text-white"
-                        : "text-slate-400 hover:text-slate-400",
+                        : "text-muted-foreground hover:text-muted-foreground",
                     )}
                   >
                     <CircleDollarSign size={18} />

--- a/components/forms/timelogForm.tsx
+++ b/components/forms/timelogForm.tsx
@@ -254,7 +254,7 @@ export const TimeLogForm = ({ projects, edit, submitHandler, recent, draft, onDr
           >
             <div className="ml-2 flex basis-[70%] items-center">
               {!isProjectSelected ? (
-                <Info className="shrink-0 text-gray-500" size={18} />
+                <Info className="text-muted-foreground shrink-0" size={18} />
               ) : (
                 <MessageSquare onClick={() => setOnCommentFocus(true)} className="shrink-0" size={18} />
               )}
@@ -281,7 +281,7 @@ export const TimeLogForm = ({ projects, edit, submitHandler, recent, draft, onDr
                   }
                   className={cn(
                     selectedData.billable && "text-success hover:text-success",
-                    !selectedData.billable && "text-slate-400 hover:text-slate-400",
+                    !selectedData.billable && "text-muted-foreground hover:text-muted-foreground",
                   )}
                 >
                   <CircleDollarSign size={20} />

--- a/components/marker-bar.tsx
+++ b/components/marker-bar.tsx
@@ -18,18 +18,18 @@ export function MarkerBar({ value, minValue, maxValue, className }: MarkerBarPro
   // Render the marker bar
   return (
     <div className={className}>
-      <div className="h-2 w-full overflow-hidden rounded-md bg-slate-200">
+      <div className="bg-muted h-2 w-full overflow-hidden rounded-md">
         <div
-          className="absolute left-0 top-0 h-full max-w-full rounded-md bg-[#f43f5e]"
+          className="bg-brand-fuchsia absolute top-0 left-0 h-full max-w-full rounded-md"
           style={{ width: `${maxValue}%` }}
         />
         <div
-          className="absolute left-0 top-0 h-full max-w-full rounded-md bg-[#32ba80]"
+          className="bg-success absolute top-0 left-0 h-full max-w-full rounded-md"
           style={{ width: `${getGreenBarWidth()}%` }}
         />
       </div>
       <div
-        className={`group absolute top-[-5px] h-[18px] w-[6px] rounded-md border border-white bg-slate-400`}
+        className="border-background bg-muted-foreground group absolute top-[-5px] h-[18px] w-[6px] rounded-md border"
         style={{ left: `${value}%` }}
       >
         <p className="invisible absolute top-[-34px] left-0 rounded-md border bg-background px-2.5 py-1 text-sm text-foreground group-hover:visible">{`${value}h`}</p>

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -24,8 +24,8 @@ export function DashboardNav({ items }: DashboardNavProps) {
             <Link key={index} href={item.disabled ? "/" : item.href}>
               <span
                 className={cn(
-                  "group flex items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-600",
-                  path === item.href ? "bg-zinc-200" : "transparent",
+                  "group flex items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
+                  path === item.href ? "bg-accent text-accent-foreground font-semibold" : "transparent",
                   item.disabled && "cursor-not-allowed opacity-80",
                 )}
               >

--- a/components/table-input.tsx
+++ b/components/table-input.tsx
@@ -113,7 +113,7 @@ export const TableInput = ({ hours, data, type, setSubmitCount }: any) => {
           onKeyUp={keypressHandler}
         />
       </PopoverTrigger>
-      <PopoverContent className="w-80 text-slate-500">
+      <PopoverContent className="text-muted-foreground w-80">
         <form method="POST" onSubmit={submitHandler} action="#FIXME" className="flex flex-col justify-center">
           <div className="mb-2 flex justify-center gap-x-[2%]">
             <div className="basis-[48%]">

--- a/components/time-entry.tsx
+++ b/components/time-entry.tsx
@@ -28,7 +28,7 @@ import { generateId } from "ai";
 import { isTimelogValid } from "@/lib/timelog-validation";
 
 // Shared config for the Classic/Board view switcher (icon toggle in the logger card header)
-const VIEW_TOGGLE_ACTIVE = "bg-zinc-200 font-medium text-zinc-900 dark:bg-zinc-700 dark:text-zinc-50";
+const VIEW_TOGGLE_ACTIVE = "bg-accent font-medium text-accent-foreground";
 const VIEW_TOGGLE_INACTIVE = "text-muted-foreground hover:bg-muted";
 
 const LOGGER_VIEWS = [

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -136,7 +136,7 @@ const ComboBox: React.FC<ComboBoxProps> = ({
         <Command className={`${searchable ? "border" : "border-0"} box-border rounded-t-[5px] border-border`}>
           {searchable && (
             <div className="space-between flex w-full items-center rounded-t-[5px] border-b border-border">
-              <Search size={16} className="ml-[10px] text-gray-400" />
+              <Search size={16} className="text-muted-foreground ml-[10px]" />
               <input
                 tabIndex={tabIndex}
                 className={`m-1 box-border h-[36px] rounded-none border-0 border-none border-border bg-popover pl-[5px] pr-[10px] text-[14px] text-popover-foreground placeholder:font-[14px] placeholder:opacity-75 focus:outline-hidden`}

--- a/components/user-account.tsx
+++ b/components/user-account.tsx
@@ -22,13 +22,13 @@ export function UserAccountNav({ user }: UserAccountNavProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>
-        <UserAvatar user={{ name: user.name ?? null, image: user.image ?? null }} className="h-8 w-8 bg-slate-300" />
+        <UserAvatar user={{ name: user.name ?? null, image: user.image ?? null }} className="h-8 w-8 bg-secondary" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <div className="flex items-center justify-start gap-2 p-2">
           <div className="flex flex-col space-y-1 leading-none">
             {user.name && <p className="font-medium">{user.name}</p>}
-            {user.email && <p className="w-[200px] truncate text-sm text-zinc-600 dark:text-zinc-100">{user.email}</p>}
+            {user.email && <p className="text-muted-foreground w-[200px] truncate text-sm">{user.email}</p>}
           </div>
         </div>
         <DropdownMenuSeparator />

--- a/lib/color-themes.ts
+++ b/lib/color-themes.ts
@@ -1,3 +1,10 @@
+import {
+  DEFAULT_CUSTOM_PRIMARY,
+  generateThemeFromPrimary,
+  readStoredCustomTheme,
+  type CustomThemeConfig,
+} from "@/lib/generate-theme";
+
 export const COLOR_THEME_STORAGE_KEY = "loggrr-color-theme";
 export const DEFAULT_COLOR_THEME = "zinc" as const;
 
@@ -12,6 +19,7 @@ export const COLOR_THEME_IDS = [
   "teal",
   "amber",
   "slate",
+  "custom",
 ] as const;
 
 export type ColorThemeId = (typeof COLOR_THEME_IDS)[number];
@@ -103,6 +111,28 @@ export function isColorThemeId(value: unknown): value is ColorThemeId {
   return typeof value === "string" && (COLOR_THEME_IDS as readonly string[]).includes(value);
 }
 
-export function getColorTheme(id: ColorThemeId): ColorThemeMeta {
+export function getCustomThemeMeta(config?: CustomThemeConfig): ColorThemeMeta {
+  const resolved = config ?? { primary: DEFAULT_CUSTOM_PRIMARY };
+  const generated = generateThemeFromPrimary(resolved.primary, resolved.accent);
+  return {
+    id: "custom",
+    name: "Custom",
+    description: "Your generated palette",
+    swatches: generated.swatches,
+    loader: generated.loader,
+  };
+}
+
+export function getColorTheme(id: ColorThemeId, customConfig?: CustomThemeConfig): ColorThemeMeta {
+  if (id === "custom") {
+    const config =
+      customConfig ?? (typeof window !== "undefined" ? readStoredCustomTheme() : { primary: DEFAULT_CUSTOM_PRIMARY });
+    return getCustomThemeMeta(config);
+  }
   return COLOR_THEMES.find((theme) => theme.id === id) ?? COLOR_THEMES[0];
+}
+
+/** Preset themes for the grid (excludes custom — shown separately). */
+export function getPresetThemes(): ColorThemeMeta[] {
+  return COLOR_THEMES;
 }

--- a/lib/color-themes.ts
+++ b/lib/color-themes.ts
@@ -1,0 +1,108 @@
+export const COLOR_THEME_STORAGE_KEY = "loggrr-color-theme";
+export const DEFAULT_COLOR_THEME = "zinc" as const;
+
+export const COLOR_THEME_IDS = [
+  "zinc",
+  "brand",
+  "ocean",
+  "forest",
+  "sunset",
+  "rose",
+  "violet",
+  "teal",
+  "amber",
+  "slate",
+] as const;
+
+export type ColorThemeId = (typeof COLOR_THEME_IDS)[number];
+
+export interface ColorThemeMeta {
+  id: ColorThemeId;
+  name: string;
+  description: string;
+  /** Hex swatches shown in the Manage picker preview */
+  swatches: [string, string, string, string];
+  /** Top-loader / accent hex used across modes */
+  loader: string;
+}
+
+export const COLOR_THEMES: ColorThemeMeta[] = [
+  {
+    id: "zinc",
+    name: "Zinc",
+    description: "Original neutral grayscale",
+    swatches: ["#18181B", "#71717A", "#E4E4E7", "#FAFAFA"],
+    loader: "#18181B",
+  },
+  {
+    id: "brand",
+    name: "Brand",
+    description: "Eggplant, fuchsia, lilac & citron",
+    swatches: ["#201547", "#F31B7C", "#E8DFF5", "#C5D92C"],
+    loader: "#F31B7C",
+  },
+  {
+    id: "ocean",
+    name: "Ocean",
+    description: "Cool sky blues",
+    swatches: ["#0369A1", "#0EA5E9", "#E0F2FE", "#F0F9FF"],
+    loader: "#0284C7",
+  },
+  {
+    id: "forest",
+    name: "Forest",
+    description: "Emerald greens",
+    swatches: ["#065F46", "#10B981", "#D1FAE5", "#ECFDF5"],
+    loader: "#059669",
+  },
+  {
+    id: "sunset",
+    name: "Sunset",
+    description: "Warm orange & coral",
+    swatches: ["#C2410C", "#F97316", "#FFEDD5", "#FFF7ED"],
+    loader: "#EA580C",
+  },
+  {
+    id: "rose",
+    name: "Rose",
+    description: "Soft rose & pink",
+    swatches: ["#9F1239", "#E11D48", "#FFE4E6", "#FFF1F2"],
+    loader: "#E11D48",
+  },
+  {
+    id: "violet",
+    name: "Violet",
+    description: "Rich purple",
+    swatches: ["#5B21B6", "#8B5CF6", "#EDE9FE", "#F5F3FF"],
+    loader: "#7C3AED",
+  },
+  {
+    id: "teal",
+    name: "Teal",
+    description: "Teal & cyan",
+    swatches: ["#115E59", "#14B8A6", "#CCFBF1", "#F0FDFA"],
+    loader: "#0D9488",
+  },
+  {
+    id: "amber",
+    name: "Amber",
+    description: "Gold & amber",
+    swatches: ["#92400E", "#F59E0B", "#FEF3C7", "#FFFBEB"],
+    loader: "#D97706",
+  },
+  {
+    id: "slate",
+    name: "Slate",
+    description: "Cool blue-gray",
+    swatches: ["#1E293B", "#64748B", "#E2E8F0", "#F8FAFC"],
+    loader: "#334155",
+  },
+];
+
+export function isColorThemeId(value: unknown): value is ColorThemeId {
+  return typeof value === "string" && (COLOR_THEME_IDS as readonly string[]).includes(value);
+}
+
+export function getColorTheme(id: ColorThemeId): ColorThemeMeta {
+  return COLOR_THEMES.find((theme) => theme.id === id) ?? COLOR_THEMES[0];
+}

--- a/lib/generate-theme.ts
+++ b/lib/generate-theme.ts
@@ -1,0 +1,266 @@
+/** Shared keys for custom theme persistence and anti-flash injection. */
+export const CUSTOM_THEME_STORAGE_KEY = "loggrr-custom-theme";
+export const CUSTOM_THEME_STYLE_ID = "loggrr-custom-theme-vars";
+export const DEFAULT_CUSTOM_PRIMARY = "#7C3AED";
+
+export interface HslColor {
+  h: number;
+  s: number;
+  l: number;
+}
+
+export interface CustomThemeConfig {
+  primary: string;
+  /** Optional secondary hue offset seed; when omitted, derived from primary. */
+  accent?: string;
+}
+
+/** Semantic tokens we override for a generated theme (HSL channels without hsl()). */
+export type ThemeTokenMap = Record<string, string>;
+
+export interface GeneratedTheme {
+  light: ThemeTokenMap;
+  dark: ThemeTokenMap;
+  swatches: [string, string, string, string];
+  loader: string;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function normalizeHex(input: string): string | null {
+  const raw = input.trim().replace(/^#/, "");
+  if (/^[0-9a-fA-F]{3}$/.test(raw)) {
+    const expanded = raw
+      .split("")
+      .map((char) => char + char)
+      .join("");
+    return `#${expanded.toUpperCase()}`;
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(raw)) return `#${raw.toUpperCase()}`;
+  return null;
+}
+
+export function hexToHsl(hex: string): HslColor {
+  const normalized = normalizeHex(hex) ?? DEFAULT_CUSTOM_PRIMARY;
+  const value = normalized.slice(1);
+  const r = parseInt(value.slice(0, 2), 16) / 255;
+  const g = parseInt(value.slice(2, 4), 16) / 255;
+  const b = parseInt(value.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  let h = 0;
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  if (delta !== 0) {
+    if (max === r) h = ((g - b) / delta) % 6;
+    else if (max === g) h = (b - r) / delta + 2;
+    else h = (r - g) / delta + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  return { h, s: s * 100, l: l * 100 };
+}
+
+export function hslToHex({ h, s, l }: HslColor): string {
+  const saturation = clamp(s, 0, 100) / 100;
+  const lightness = clamp(l, 0, 100) / 100;
+  const c = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lightness - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+
+  const toHex = (channel: number) =>
+    Math.round((channel + m) * 255)
+      .toString(16)
+      .padStart(2, "0")
+      .toUpperCase();
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function channel(h: number, s: number, l: number): string {
+  return `${Math.round(h)} ${Math.round(clamp(s, 0, 100))}% ${Math.round(clamp(l, 0, 100))}%`;
+}
+
+function relativeLuminance(hex: string): number {
+  const normalized = normalizeHex(hex) ?? DEFAULT_CUSTOM_PRIMARY;
+  const value = normalized.slice(1);
+  const channels = [0, 2, 4].map((i) => {
+    const c = parseInt(value.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function readableForeground(backgroundHex: string): string {
+  return relativeLuminance(backgroundHex) > 0.4 ? "0 0% 4%" : "0 0% 100%";
+}
+
+function oklchApprox(h: number, chroma: number, lightness: number): string {
+  // Charts already use oklch elsewhere; approximate from hue for variety.
+  return `oklch(${lightness.toFixed(2)} ${chroma.toFixed(2)} ${Math.round(h)})`;
+}
+
+/** Build full light/dark semantic tokens from a primary (and optional accent) hex. */
+export function generateThemeFromPrimary(primaryHex: string, accentHex?: string): GeneratedTheme {
+  const primary = hexToHsl(normalizeHex(primaryHex) ?? DEFAULT_CUSTOM_PRIMARY);
+  const accentSource = accentHex ? hexToHsl(normalizeHex(accentHex) ?? primaryHex) : primary;
+  const h = primary.h;
+  const a = accentSource.h;
+  const sat = clamp(primary.s, 35, 90);
+
+  const lightPrimaryL = clamp(primary.l > 45 ? primary.l - 20 : primary.l, 22, 42);
+  const darkPrimaryL = clamp(primary.l < 55 ? primary.l + 15 : primary.l, 48, 68);
+  const lightPrimaryHex = hslToHex({ h, s: sat, l: lightPrimaryL });
+  const darkPrimaryHex = hslToHex({ h, s: sat, l: darkPrimaryL });
+
+  const light: ThemeTokenMap = {
+    "--background": channel(h, Math.min(sat, 40), 98.5),
+    "--foreground": channel(h, Math.min(sat, 40), 10),
+    "--card": "0 0% 100%",
+    "--card-foreground": channel(h, Math.min(sat, 40), 10),
+    "--popover": "0 0% 100%",
+    "--popover-foreground": channel(h, Math.min(sat, 40), 10),
+    "--primary": channel(h, sat, lightPrimaryL),
+    "--primary-foreground": readableForeground(lightPrimaryHex),
+    "--secondary": channel(a, Math.min(sat, 45), 94),
+    "--secondary-foreground": channel(h, sat * 0.7, 20),
+    "--muted": channel(h, Math.min(sat, 30), 95),
+    "--muted-foreground": channel(h, 12, 42),
+    "--accent": channel(a, Math.min(sat, 55), 92),
+    "--accent-foreground": channel(h, sat * 0.8, 22),
+    "--border": channel(h, Math.min(sat, 25), 88),
+    "--input": channel(h, Math.min(sat, 25), 88),
+    "--ring": channel(h, sat, clamp(lightPrimaryL + 12, 35, 55)),
+    "--chart-1": oklchApprox(h, 0.18, 0.55),
+    "--chart-2": oklchApprox((h + 40) % 360, 0.14, 0.65),
+    "--chart-3": oklchApprox((h + 80) % 360, 0.12, 0.5),
+    "--chart-4": oklchApprox((h + 140) % 360, 0.1, 0.72),
+    "--chart-5": oklchApprox((h + 200) % 360, 0.1, 0.45),
+    "--sidebar": `oklch(0.98 ${Math.min(sat / 400, 0.03).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-foreground": `oklch(0.22 ${Math.min(sat / 250, 0.05).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-primary": `oklch(0.42 ${Math.min(sat / 200, 0.14).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-primary-foreground": "oklch(0.99 0 0)",
+    "--sidebar-accent": `oklch(0.94 ${Math.min(sat / 300, 0.04).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-accent-foreground": `oklch(0.28 ${Math.min(sat / 220, 0.08).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-border": `oklch(0.9 ${Math.min(sat / 400, 0.03).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-ring": `oklch(0.65 ${Math.min(sat / 180, 0.16).toFixed(3)} ${Math.round(h)})`,
+  };
+
+  const dark: ThemeTokenMap = {
+    "--background": channel(h, Math.min(sat, 35), 7),
+    "--foreground": channel(h, Math.min(sat, 30), 96),
+    "--card": channel(h, Math.min(sat, 30), 10),
+    "--card-foreground": channel(h, Math.min(sat, 30), 96),
+    "--popover": channel(h, Math.min(sat, 30), 10),
+    "--popover-foreground": channel(h, Math.min(sat, 30), 96),
+    "--primary": channel(h, sat, darkPrimaryL),
+    "--primary-foreground": readableForeground(darkPrimaryHex),
+    "--secondary": channel(h, Math.min(sat, 25), 16),
+    "--secondary-foreground": channel(h, Math.min(sat, 30), 96),
+    "--muted": channel(h, Math.min(sat, 22), 15),
+    "--muted-foreground": channel(h, 12, 68),
+    "--accent": channel(a, Math.min(sat, 28), 18),
+    "--accent-foreground": channel(a, Math.min(sat, 50), 88),
+    "--border": channel(h, Math.min(sat, 20), 18),
+    "--input": channel(h, Math.min(sat, 20), 18),
+    "--ring": channel(h, sat, darkPrimaryL),
+    "--chart-1": oklchApprox(h, 0.16, 0.7),
+    "--chart-2": oklchApprox((h + 40) % 360, 0.12, 0.75),
+    "--chart-3": oklchApprox((h + 80) % 360, 0.1, 0.62),
+    "--chart-4": oklchApprox((h + 140) % 360, 0.09, 0.8),
+    "--chart-5": oklchApprox((h + 200) % 360, 0.1, 0.55),
+    "--sidebar": `oklch(0.16 ${Math.min(sat / 350, 0.04).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-foreground": `oklch(0.95 ${Math.min(sat / 500, 0.02).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-primary": `oklch(0.68 ${Math.min(sat / 180, 0.16).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-primary-foreground": `oklch(0.15 ${Math.min(sat / 300, 0.04).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-accent": `oklch(0.24 ${Math.min(sat / 350, 0.04).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-accent-foreground": `oklch(0.95 ${Math.min(sat / 500, 0.02).toFixed(3)} ${Math.round(h)})`,
+    "--sidebar-border": "oklch(1 0 0 / 10%)",
+    "--sidebar-ring": `oklch(0.68 ${Math.min(sat / 180, 0.16).toFixed(3)} ${Math.round(h)})`,
+  };
+
+  return {
+    light,
+    dark,
+    swatches: [
+      lightPrimaryHex,
+      hslToHex({ h, s: sat, l: 55 }),
+      hslToHex({ h, s: Math.min(sat, 40), l: 90 }),
+      hslToHex({ h, s: Math.min(sat, 30), l: 97 }),
+    ],
+    loader: lightPrimaryHex,
+  };
+}
+
+function tokensToCss(selector: string, tokens: ThemeTokenMap): string {
+  const body = Object.entries(tokens)
+    .map(([key, value]) => `${key}:${value};`)
+    .join("");
+  return `${selector}{${body}}`;
+}
+
+/** CSS block injected for `[data-theme="custom"]` light + dark. */
+export function buildCustomThemeCss(config: CustomThemeConfig): string {
+  const generated = generateThemeFromPrimary(config.primary, config.accent);
+  return [
+    tokensToCss('[data-theme="custom"]', generated.light),
+    tokensToCss('.dark[data-theme="custom"]', generated.dark),
+  ].join("");
+}
+
+export function injectCustomThemeStyle(css: string) {
+  if (typeof document === "undefined") return;
+  let style = document.getElementById(CUSTOM_THEME_STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement("style");
+    style.id = CUSTOM_THEME_STYLE_ID;
+    document.head.appendChild(style);
+  }
+  style.textContent = css;
+}
+
+export function removeCustomThemeStyle() {
+  if (typeof document === "undefined") return;
+  document.getElementById(CUSTOM_THEME_STYLE_ID)?.remove();
+}
+
+export function readStoredCustomTheme(): CustomThemeConfig {
+  if (typeof window === "undefined") return { primary: DEFAULT_CUSTOM_PRIMARY };
+  try {
+    const raw = localStorage.getItem(CUSTOM_THEME_STORAGE_KEY);
+    if (!raw) return { primary: DEFAULT_CUSTOM_PRIMARY };
+    const parsed = JSON.parse(raw) as CustomThemeConfig;
+    const primary = normalizeHex(parsed.primary ?? "") ?? DEFAULT_CUSTOM_PRIMARY;
+    const accent = parsed.accent ? normalizeHex(parsed.accent) ?? undefined : undefined;
+    return { primary, accent };
+  } catch {
+    return { primary: DEFAULT_CUSTOM_PRIMARY };
+  }
+}
+
+export function persistCustomTheme(config: CustomThemeConfig) {
+  const primary = normalizeHex(config.primary) ?? DEFAULT_CUSTOM_PRIMARY;
+  const accent = config.accent ? normalizeHex(config.accent) ?? undefined : undefined;
+  const next: CustomThemeConfig = { primary, ...(accent ? { accent } : {}) };
+  localStorage.setItem(CUSTOM_THEME_STORAGE_KEY, JSON.stringify(next));
+  const css = buildCustomThemeCss(next);
+  localStorage.setItem(`${CUSTOM_THEME_STORAGE_KEY}-css`, css);
+  injectCustomThemeStyle(css);
+  return next;
+}

--- a/lib/random-colors.ts
+++ b/lib/random-colors.ts
@@ -1,37 +1,21 @@
-// Function to pad a string with leading zeros to ensure it has at least 2 characters
-const padWithZeros = (str: string) => {
-  return str.length < 2 ? `0${str}` : str;
-};
+/** Brand-harmonious palette for project dots and similar accents. */
+const BRAND_PALETTE = [
+  "#201547", // eggplant
+  "#F31B7C", // fuchsia
+  "#C4B5E0", // lilac mid
+  "#C5D92C", // citron
+  "#7C3AED", // violet
+  "#0D9488", // teal
+  "#DB2777", // pink
+  "#6366F1", // indigo
+  "#CA8A04", // gold
+  "#059669", // emerald
+  "#9333EA", // purple
+  "#E11D48", // rose
+];
 
-const customRandom = (seed: number) => {
-  let state = seed;
-  return () => {
-    // Initialize a custom pseudo-random number generator
-    state = (state * 9301 + 49297) % 233280;
-    return state / 233280;
-  };
-};
-
-// Function to get random dark colors
+/** Deterministic color from a stable index (e.g. project id). */
 export const getRandomColor = (index: number) => {
-  // Define the maximum value for each color component (0-255)
-  const maxColorValue = 255;
-
-  // Create a deterministic seed based on the index
-  const seed = index * 9973; // You can choose any prime number as the multiplier
-
-  // Use the seed to initialize a custom pseudo-random number generator
-  const rng = customRandom(seed);
-
-  // Generate random values for red, green, and blue components
-  const red = Math.floor(rng() * maxColorValue * 0.5); // Limit red to 0-127
-  const green = Math.floor(rng() * maxColorValue * 0.5); // Limit green to 0-127
-  const blue = Math.floor(rng() * maxColorValue * 0.5); // Limit blue to 0-127
-
-  // Convert the RGB components to a hexadecimal color representation with leading zeros
-  const darkColor = `#${padWithZeros(red.toString(16))}${padWithZeros(
-    green.toString(16),
-  )}${padWithZeros(blue.toString(16))}`;
-
-  return darkColor;
+  const normalized = Math.abs(Math.trunc(index));
+  return BRAND_PALETTE[normalized % BRAND_PALETTE.length];
 };


### PR DESCRIPTION
## Summary
- Adds 10 selectable color palettes (Zinc, Brand, Ocean, Forest, Sunset, Rose, Violet, Teal, Amber, Slate) stored via `data-theme` on `<html>` and persisted in `localStorage`
- Keeps light/dark mode independent through existing `next-themes` — default remains Zinc + light (original neutral look)
- Rebuilds Manage → Appearance with a mode toggle and visual theme grid; wires a `ColorThemeProvider`, anti-flash init script, and theme-aware top loader
- Replaces hardcoded zinc/slate chrome with semantic tokens so UI chrome and charts follow the active palette

## Test plan
- [ ] Open Manage → Appearance; confirm Zinc is selected by default and the app looks neutral B&W
- [ ] Switch Light/Dark without changing palette — mode updates independently
- [ ] Select each of the 10 palettes in light and dark; verify buttons, cards, borders, focus rings, and charts pick up the new colors
- [ ] Reload the page — selected palette persists (no flash of wrong theme)
- [ ] Confirm logo still uses brand eggplant/fuchsia/lilac accents regardless of palette
- [ ] Toggle theme via mobile menu / command palette — only light/dark changes, palette stays
- [ ] Spot-check dashboard home (heatmap, hours bar), projects table, and auth pages for readable contrast


Made with [Cursor](https://cursor.com)