### PR TITLE
fix: Align Report date filters with Overview

### DIFF
--- a/app/[team]/projects/[project]/(projects)/reports/page.tsx
+++ b/app/[team]/projects/[project]/(projects)/reports/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { startOfMonth } from "date-fns";
 
 import { pageProps } from "@/types";
 import {
@@ -27,9 +28,17 @@ export default async function Page(props: pageProps) {
   }
 
   const projectId = +project;
-  const { startDate, endDate } = getStartandEndDates(searchParams.range, 30);
+  const projectDetails = await getProjectDetailsById(team, projectId);
+  const selectedRange = searchParams.range;
+  const isFixed = projectDetails?.interval === "FIXED";
 
-  const [matrix, allMembers, allCategories, allTasks, projectDetails] = await Promise.all([
+  const { startDate, endDate } = selectedRange
+    ? getStartandEndDates(selectedRange)
+    : isFixed
+      ? { startDate: projectDetails?.createdAt ?? startOfMonth(new Date()), endDate: new Date() }
+      : getStartandEndDates("");
+
+  const [matrix, allMembers, allCategories, allTasks] = await Promise.all([
     getProjectMatrix(
       team,
       projectId,
@@ -43,7 +52,6 @@ export default async function Page(props: pageProps) {
     getMembersNameInTimeEntries(team, projectId),
     getMilestonesInProject(team, projectId),
     getTasksInProject(team, projectId),
-    getProjectDetailsById(team, projectId),
   ]);
   const isBillable = projectDetails?.billable ?? false;
 
@@ -54,6 +62,8 @@ export default async function Page(props: pageProps) {
         allMembers={allMembers}
         allCategories={allCategories}
         allTasks={allTasks}
+        interval={projectDetails?.interval}
+        projectCreatedAt={projectDetails?.createdAt?.toISOString()}
       />
       <ProjectMatrix data={matrix} />
     </div>

--- a/app/[team]/projects/[project]/components/toolbar.tsx
+++ b/app/[team]/projects/[project]/components/toolbar.tsx
@@ -45,8 +45,14 @@ export function DataTableToolbar({
   const selectedMembers = searchParams.get("members");
   const selectedCategory = searchParams.get("category");
   const selectedTask = searchParams.get("task");
-  const defaultDay = selectedRange ? undefined : 30;
   const selectedProject = pathname.includes("projects") ? pathname.split("/")[3] : null;
+
+  const isFixed = interval === "FIXED";
+  const [start, end] = selectedRange?.split(",") || [];
+  const monthStart = startOfMonth(startOfToday());
+  const fixedStart = projectCreatedAt ? startOfDay(new Date(projectCreatedAt)) : monthStart;
+  const startFrom = (start && startOfDay(new Date(start))) || (isFixed ? fixedStart : monthStart);
+  const endTo = (end && startOfDay(new Date(end))) || startOfToday();
 
   const peopleFilter = {
     title: "Members",
@@ -81,15 +87,17 @@ export function DataTableToolbar({
   const handleExportClick = async () => {
     try {
       setIsExportLoading(true);
+      // Match Overview/Report defaults when no explicit range is in the URL
+      const rangeForExport =
+        selectedRange ?? `${format(startFrom, "MM-dd-yyyy")},${format(endTo, "MM-dd-yyyy")}`;
       const response = await fetch("/api/team/export", {
         method: "POST",
         body: JSON.stringify({
           slug,
-          selectedRange,
+          selectedRange: rangeForExport,
           selectedBilling,
           selectedMembers,
           selectedProject,
-          defaultDay,
         }),
       });
 
@@ -127,13 +135,6 @@ export function DataTableToolbar({
   const updateDateRange = (range: string) => {
     router.push(pathname + "?" + createQueryString("range", range));
   };
-
-  const isFixed = interval === "FIXED";
-  const [start, end] = selectedRange?.split(",") || [];
-  const monthStart = startOfMonth(startOfToday());
-  const fixedStart = projectCreatedAt ? startOfDay(new Date(projectCreatedAt)) : monthStart;
-  const startFrom = (start && startOfDay(new Date(start))) || (isFixed ? fixedStart : monthStart);
-  const endTo = (end && startOfDay(new Date(end))) || startOfToday();
 
   // Billing status toggle button
   const billingStatusToggleButton = (


### PR DESCRIPTION
## Summary
- Make Report use the same default date window as Overview (month-to-date for monthly projects, project created → now for FIXED)
- Pass `interval` and `projectCreatedAt` into the Report toolbar so the date picker matches the server query
- Export CSV using that same resolved range instead of falling back to last 30 days

## Test plan
- [x] Open Overview and Report on a monthly project with no `?range=` — totals should match (month-to-date)
- [x] Confirm Report date picker shows month start → today by default (not a misleading Jul 1 label over last-30 data)
- [x] Apply the same `range`, members, category, task, and billable filters on both pages — totals stay in sync
- [x] On a FIXED project with no range, both pages use project created → now
- [x] Export CSV with no range selected and verify the file covers the same default window as the UI


Made with [Cursor](https://cursor.com)